### PR TITLE
refactor: implement P2 code quality audit fixes (#17-#29) (#41)

### DIFF
--- a/CODE_QUALITY_AUDIT.md
+++ b/CODE_QUALITY_AUDIT.md
@@ -578,19 +578,19 @@ Following the initial security/performance audit (see `AUDIT.md`), this audit fo
 | 14  | Missing explicit return types on services          | 3      | M      | P1       | Done   |
 | 15  | DELETE 200 vs 204 inconsistency                    | 3      | S      | P1       | Done   |
 | 16  | Logout returns `200 { success: false }`            | 3      | S      | P1       | Done   |
-| 17  | `PUT /users/:id/role` should be `PATCH`            | 3      | S      | P2       | Todo   |
-| 18  | GET vs POST `/auth/refresh-token` collision        | 2      | S      | P2       | Todo   |
-| 19  | `totalPages` missing from Swagger schema           | 3      | S      | P2       | Todo   |
-| 20  | `currencyCode` required in analytics only          | 2      | S      | P2       | Todo   |
-| 21  | No `dateFrom <= dateTo` cross-field validation     | 3      | S      | P2       | Todo   |
-| 22  | `AuditLogQueryDto` in controller file              | 2      | S      | P2       | Todo   |
-| 23  | Redundant `@Global()` CacheModule imports          | 2      | S      | P2       | Todo   |
-| 24  | Auth revoke missing throttle band                  | 3      | S      | P2       | Todo   |
-| 25  | `RegisterDto` missing `!` on properties            | 2      | S      | P2       | Todo   |
-| 26  | `CreateUserDto.name` vs `firstName/lastName`       | 3      | S      | P2       | Todo   |
-| 27  | `CategoryQueryDto.root` no boolean validation      | 2      | S      | P2       | Todo   |
-| 28  | Audit interceptor inline type casts                | 2      | S      | P2       | Todo   |
-| 29  | Missing `import type` for `AnyPgColumn`            | 1      | S      | P2       | Todo   |
+| 17  | `PUT /users/:id/role` should be `PATCH`            | 3      | S      | P2       | Done   |
+| 18  | GET vs POST `/auth/refresh-token` collision        | 2      | S      | P2       | Done   |
+| 19  | `totalPages` missing from Swagger schema           | 3      | S      | P2       | Done   |
+| 20  | `currencyCode` required in analytics only          | 2      | S      | P2       | Done   |
+| 21  | No `dateFrom <= dateTo` cross-field validation     | 3      | S      | P2       | Done   |
+| 22  | `AuditLogQueryDto` in controller file              | 2      | S      | P2       | Done   |
+| 23  | Redundant `@Global()` CacheModule imports          | 2      | S      | P2       | Done   |
+| 24  | Auth revoke missing throttle band                  | 3      | S      | P2       | Done   |
+| 25  | `RegisterDto` missing `!` on properties            | 2      | S      | P2       | Done   |
+| 26  | `CreateUserDto.name` vs `firstName/lastName`       | 3      | S      | P2       | Done   |
+| 27  | `CategoryQueryDto.root` no boolean validation      | 2      | S      | P2       | Done   |
+| 28  | Audit interceptor inline type casts                | 2      | S      | P2       | Done   |
+| 29  | Missing `import type` for `AnyPgColumn`            | 1      | S      | P2       | Done   |
 | 30  | No text search on transactions                     | 3      | M      | P3       | Todo   |
 | 31  | Response DTOs expose `userId`                      | 2      | S      | P3       | Todo   |
 | 32  | `interval` has no maximum                          | 2      | S      | P3       | Todo   |

--- a/src/database/schemas/refresh-tokens.ts
+++ b/src/database/schemas/refresh-tokens.ts
@@ -1,4 +1,4 @@
-import { AnyPgColumn, index, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { type AnyPgColumn, index, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 
 import { users } from './users.js';

--- a/src/modules/audit-log/audit-log.controller.ts
+++ b/src/modules/audit-log/audit-log.controller.ts
@@ -1,58 +1,13 @@
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
-import {
-  ApiBearerAuth,
-  ApiOperation,
-  ApiResponse,
-  ApiTags,
-  ApiPropertyOptional,
-} from '@nestjs/swagger';
-import { IsIn, IsOptional, IsString } from 'class-validator';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
-import { SORT_ORDERS } from '@/shared/constants/sort.constants.js';
-import type { SortOrder } from '@/shared/constants/sort.constants.js';
-import { OffsetPaginationDto } from '@/shared/dtos/pagination.dto.js';
 import { Roles } from '@/shared/decorators/roles.decorator.js';
 import { JwtAuthGuard, RolesGuard } from '@/shared/guards/index.js';
 import { buildPaginatedResponse } from '@/shared/utils/pagination.utils.js';
 
-import { SORT_BY_FIELDS } from './audit-log.constants.js';
-import type { SortByField } from './audit-log.constants.js';
 import { AuditLogService } from './audit-log.service.js';
 import { AuditLogListResponseDto } from './dtos/audit-log-list-response.dto.js';
-
-export class AuditLogQueryDto extends OffsetPaginationDto {
-  @ApiPropertyOptional({ example: '550e8400-e29b-41d4-a716-446655440000' })
-  @IsOptional()
-  @IsString()
-  actorId?: string;
-
-  @ApiPropertyOptional({ example: 'POST /api/auth/login' })
-  @IsOptional()
-  @IsString()
-  action?: string;
-
-  @ApiPropertyOptional({
-    example: 'createdAt',
-    type: String,
-    enum: SORT_BY_FIELDS,
-    enumName: 'AuditLogSortBy',
-    description: 'Field to sort by (default: createdAt)',
-  })
-  @IsOptional()
-  @IsIn(SORT_BY_FIELDS)
-  sortBy?: SortByField;
-
-  @ApiPropertyOptional({
-    example: 'desc',
-    type: String,
-    enum: SORT_ORDERS,
-    enumName: 'SortOrder',
-    description: 'Sort direction (default: desc)',
-  })
-  @IsOptional()
-  @IsIn(SORT_ORDERS)
-  sortOrder?: SortOrder;
-}
+import { AuditLogQueryDto } from './dtos/audit-log-query.dto.js';
 
 @ApiTags('Audit Logs')
 @Controller('audit-logs')

--- a/src/modules/audit-log/audit-log.interceptor.ts
+++ b/src/modules/audit-log/audit-log.interceptor.ts
@@ -4,6 +4,8 @@ import type { NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/com
 import type { Request } from 'express';
 import type { Observable } from 'rxjs';
 
+import type { AuthUser } from '@/modules/auth/auth.types.js';
+
 import { AuditLogService } from './audit-log.service.js';
 
 const MUTATING_METHODS = new Set(['POST', 'PATCH', 'PUT', 'DELETE']);
@@ -14,8 +16,8 @@ export class AuditLogInterceptor implements NestInterceptor {
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const req = context.switchToHttp().getRequest<Request>();
-    const { method, url, params } = req;
-    const user = req.user as { id: string; email?: string } | undefined;
+    const { method, url } = req;
+    const user = req.user as AuthUser | undefined;
 
     if (!MUTATING_METHODS.has(method) || !user) {
       return next.handle();
@@ -27,7 +29,7 @@ export class AuditLogInterceptor implements NestInterceptor {
           action: `${method} ${url}`,
           actorId: user.id,
           actorEmail: user.email,
-          resourceId: (params as Record<string, string>)?.id,
+          resourceId: (req.params as Record<string, string>)?.id,
         });
       }),
     );

--- a/src/modules/audit-log/dtos/audit-log-query.dto.ts
+++ b/src/modules/audit-log/dtos/audit-log-query.dto.ts
@@ -1,0 +1,43 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsOptional, IsString } from 'class-validator';
+
+import { SORT_ORDERS } from '@/shared/constants/sort.constants.js';
+import type { SortOrder } from '@/shared/constants/sort.constants.js';
+import { OffsetPaginationDto } from '@/shared/dtos/pagination.dto.js';
+
+import { SORT_BY_FIELDS } from '../audit-log.constants.js';
+import type { SortByField } from '../audit-log.constants.js';
+
+export class AuditLogQueryDto extends OffsetPaginationDto {
+  @ApiPropertyOptional({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  @IsOptional()
+  @IsString()
+  actorId?: string;
+
+  @ApiPropertyOptional({ example: 'POST /api/auth/login' })
+  @IsOptional()
+  @IsString()
+  action?: string;
+
+  @ApiPropertyOptional({
+    example: 'createdAt',
+    type: String,
+    enum: SORT_BY_FIELDS,
+    enumName: 'AuditLogSortBy',
+    description: 'Field to sort by (default: createdAt)',
+  })
+  @IsOptional()
+  @IsIn(SORT_BY_FIELDS)
+  sortBy?: SortByField;
+
+  @ApiPropertyOptional({
+    example: 'desc',
+    type: String,
+    enum: SORT_ORDERS,
+    enumName: 'SortOrder',
+    description: 'Sort direction (default: desc)',
+  })
+  @IsOptional()
+  @IsIn(SORT_ORDERS)
+  sortOrder?: SortOrder;
+}

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -118,7 +118,7 @@ export class AuthController {
     return { accessToken: result.accessToken, user: result.user };
   }
 
-  @Get('refresh-token')
+  @Get('refresh-token/info')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get current refresh token info' })
@@ -155,6 +155,7 @@ export class AuthController {
   }
 
   @Post('revoke-refresh-token')
+  @Throttle({ auth: {} })
   @HttpCode(200)
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
@@ -172,6 +173,7 @@ export class AuthController {
   }
 
   @Post('revoke-refresh-tokens')
+  @Throttle({ auth: {} })
   @HttpCode(200)
   @UseGuards(JwtAuthGuard, CsrfGuard)
   @ApiBearerAuth()

--- a/src/modules/auth/dtos/register.dto.ts
+++ b/src/modules/auth/dtos/register.dto.ts
@@ -13,7 +13,7 @@ import {
 export class RegisterDto {
   @ApiProperty({ example: 'user@example.com' })
   @IsEmailField({ message: 'Invalid email format' })
-  email: string;
+  email!: string;
 
   @ApiProperty({ example: 'Pass123456' })
   @IsStringField()
@@ -23,7 +23,7 @@ export class RegisterDto {
   @MatchesField(/^(?=.*[a-zA-Z])(?=.*\d)/, {
     message: 'Password must contain at least one letter and one digit',
   })
-  password: string;
+  password!: string;
 
   @ApiPropertyOptional({ example: 'John' })
   @IsOptional()

--- a/src/modules/budgets/budgets.module.ts
+++ b/src/modules/budgets/budgets.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 
-import { CacheModule } from '@/modules/cache/cache.module.js';
 import { TransactionCategoriesModule } from '@/modules/transaction-categories/transaction-categories.module.js';
 
 import { BudgetsCacheListener } from './budgets-cache.listener.js';
@@ -9,7 +8,7 @@ import { BudgetRepository } from './budgets.repository.js';
 import { BudgetsService } from './budgets.service.js';
 
 @Module({
-  imports: [CacheModule, TransactionCategoriesModule],
+  imports: [TransactionCategoriesModule],
   controllers: [BudgetsController],
   providers: [BudgetsService, BudgetRepository, BudgetsCacheListener],
   exports: [BudgetsService],

--- a/src/modules/budgets/dtos/create-budget.dto.ts
+++ b/src/modules/budgets/dtos/create-budget.dto.ts
@@ -3,6 +3,7 @@ import { IsIn, IsOptional } from 'class-validator';
 
 import {
   IsISO8601Field,
+  IsNotBeforeField,
   IsNotEmptyField,
   IsStringField,
   IsUUIDField,
@@ -36,6 +37,7 @@ export class CreateBudgetDto {
   @ApiPropertyOptional({ example: '2026-03-31T23:59:59.999+02:00' })
   @IsOptional()
   @IsISO8601Field()
+  @IsNotBeforeField('startDate')
   endDate?: string;
 
   @ApiPropertyOptional({ example: '550e8400-e29b-41d4-a716-446655440000' })

--- a/src/modules/default-transaction-categories/dtos/default-transaction-category-query.dto.ts
+++ b/src/modules/default-transaction-categories/dtos/default-transaction-category-query.dto.ts
@@ -5,6 +5,7 @@ import { Transform, Type } from 'class-transformer';
 import { SORT_ORDERS } from '@/shared/constants/sort.constants.js';
 import type { SortOrder } from '@/shared/constants/sort.constants.js';
 import { OffsetPaginationDto } from '@/shared/dtos/pagination.dto.js';
+import { IsBooleanField } from '@/shared/decorators/validators.js';
 import { TRANSACTION_TYPES } from '@/shared/enums/transaction-type.enum.js';
 import type { TransactionType } from '@/shared/enums/transaction-type.enum.js';
 
@@ -26,6 +27,7 @@ export class DefaultTransactionCategoryQueryDto extends OffsetPaginationDto {
   @IsOptional()
   @Type(() => Boolean)
   @Transform(({ value }) => value === 'true' || value === true)
+  @IsBooleanField()
   root?: boolean;
 
   @ApiPropertyOptional({

--- a/src/modules/default-transaction-categories/dtos/default-transaction-category-query.dto.ts
+++ b/src/modules/default-transaction-categories/dtos/default-transaction-category-query.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional } from 'class-validator';
-import { Transform, Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
 
 import { SORT_ORDERS } from '@/shared/constants/sort.constants.js';
 import type { SortOrder } from '@/shared/constants/sort.constants.js';
@@ -25,8 +25,16 @@ export class DefaultTransactionCategoryQueryDto extends OffsetPaginationDto {
 
   @ApiPropertyOptional({ example: true })
   @IsOptional()
-  @Type(() => Boolean)
-  @Transform(({ value }) => value === 'true' || value === true)
+  @Transform(({ value }: { value: unknown }) => {
+    if (value === 'true' || value === true) {
+      return true;
+    }
+    if (value === 'false' || value === false) {
+      return false;
+    }
+
+    return value;
+  })
   @IsBooleanField()
   root?: boolean;
 

--- a/src/modules/profile/profile.module.ts
+++ b/src/modules/profile/profile.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common';
 
-import { CacheModule } from '@/modules/cache/cache.module.js';
 import { UserModule } from '@/modules/user/user.module.js';
 
 import { ProfileController } from './profile.controller.js';
 import { ProfileService } from './profile.service.js';
 
 @Module({
-  imports: [UserModule, CacheModule],
+  imports: [UserModule],
   controllers: [ProfileController],
   providers: [ProfileService],
 })

--- a/src/modules/recurring-transactions/recurring-transactions.module.ts
+++ b/src/modules/recurring-transactions/recurring-transactions.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 
-import { CacheModule } from '@/modules/cache/cache.module.js';
 import { TransactionCategoriesModule } from '@/modules/transaction-categories/transaction-categories.module.js';
 
 import { RecurringTransactionsController } from './recurring-transactions.controller.js';
@@ -8,7 +7,7 @@ import { RecurringTransactionsRepository } from './recurring-transactions.reposi
 import { RecurringTransactionsService } from './recurring-transactions.service.js';
 
 @Module({
-  imports: [CacheModule, TransactionCategoriesModule],
+  imports: [TransactionCategoriesModule],
   controllers: [RecurringTransactionsController],
   providers: [RecurringTransactionsService, RecurringTransactionsRepository],
   exports: [RecurringTransactionsService],

--- a/src/modules/transaction-categories/dtos/category-query.dto.ts
+++ b/src/modules/transaction-categories/dtos/category-query.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional } from 'class-validator';
-import { Transform, Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
 
 import { SORT_ORDERS } from '@/shared/constants/sort.constants.js';
 import type { SortOrder } from '@/shared/constants/sort.constants.js';
@@ -30,8 +30,16 @@ export class CategoryQueryDto extends OffsetPaginationDto {
 
   @ApiPropertyOptional({ example: true })
   @IsOptional()
-  @Type(() => Boolean)
-  @Transform(({ value }) => value === 'true' || value === true)
+  @Transform(({ value }: { value: unknown }) => {
+    if (value === 'true' || value === true) {
+      return true;
+    }
+    if (value === 'false' || value === false) {
+      return false;
+    }
+
+    return value;
+  })
   @IsBooleanField()
   root?: boolean;
 

--- a/src/modules/transaction-categories/dtos/category-query.dto.ts
+++ b/src/modules/transaction-categories/dtos/category-query.dto.ts
@@ -5,7 +5,7 @@ import { Transform, Type } from 'class-transformer';
 import { SORT_ORDERS } from '@/shared/constants/sort.constants.js';
 import type { SortOrder } from '@/shared/constants/sort.constants.js';
 import { OffsetPaginationDto } from '@/shared/dtos/pagination.dto.js';
-import { IsUUIDField } from '@/shared/decorators/validators.js';
+import { IsBooleanField, IsUUIDField } from '@/shared/decorators/validators.js';
 import { TRANSACTION_TYPES } from '@/shared/enums/transaction-type.enum.js';
 import type { TransactionType } from '@/shared/enums/transaction-type.enum.js';
 
@@ -32,6 +32,7 @@ export class CategoryQueryDto extends OffsetPaginationDto {
   @IsOptional()
   @Type(() => Boolean)
   @Transform(({ value }) => value === 'true' || value === true)
+  @IsBooleanField()
   root?: boolean;
 
   @ApiPropertyOptional({

--- a/src/modules/transaction-categories/transaction-categories.module.ts
+++ b/src/modules/transaction-categories/transaction-categories.module.ts
@@ -1,13 +1,10 @@
 import { Module } from '@nestjs/common';
 
-import { CacheModule } from '@/modules/cache/cache.module.js';
-
 import { TransactionCategoriesController } from './transaction-categories.controller.js';
 import { TransactionCategoryRepository } from './transaction-categories.repository.js';
 import { TransactionCategoriesService } from './transaction-categories.service.js';
 
 @Module({
-  imports: [CacheModule],
   controllers: [TransactionCategoriesController],
   providers: [TransactionCategoriesService, TransactionCategoryRepository],
   exports: [TransactionCategoriesService, TransactionCategoryRepository],

--- a/src/modules/transactions-analytics/dtos/analytics-query.dto.ts
+++ b/src/modules/transactions-analytics/dtos/analytics-query.dto.ts
@@ -1,16 +1,27 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsOptional } from 'class-validator';
 
-import { IsISO8601Field, IsInField, IsUUIDField } from '@/shared/decorators/validators.js';
+import {
+  IsISO8601Field,
+  IsInField,
+  IsNotBeforeField,
+  IsUUIDField,
+} from '@/shared/decorators/validators.js';
 import { CURRENCY_CODES } from '@/shared/enums/currency-code.enum.js';
 import type { CurrencyCode } from '@/shared/enums/currency-code.enum.js';
 import { TRANSACTION_TYPES } from '@/shared/enums/transaction-type.enum.js';
 import type { TransactionType } from '@/shared/enums/transaction-type.enum.js';
 
 export class AnalyticsQueryDto {
-  @ApiProperty({ example: 'USD', type: String, enum: CURRENCY_CODES, enumName: 'CurrencyCode' })
+  @ApiPropertyOptional({
+    example: 'USD',
+    type: String,
+    enum: CURRENCY_CODES,
+    enumName: 'CurrencyCode',
+  })
+  @IsOptional()
   @IsInField([...CURRENCY_CODES])
-  currencyCode!: CurrencyCode;
+  currencyCode?: CurrencyCode;
 
   @ApiPropertyOptional({ example: '2026-03-01T00:00:00.000+02:00' })
   @IsOptional()
@@ -20,6 +31,7 @@ export class AnalyticsQueryDto {
   @ApiPropertyOptional({ example: '2026-03-31T23:59:59.999+02:00' })
   @IsOptional()
   @IsISO8601Field()
+  @IsNotBeforeField('dateFrom')
   dateTo?: string;
 
   @ApiPropertyOptional({

--- a/src/modules/transactions-analytics/dtos/daily-spending-query.dto.ts
+++ b/src/modules/transactions-analytics/dtos/daily-spending-query.dto.ts
@@ -23,9 +23,15 @@ export class DailySpendingQueryDto {
   @MaxField(12)
   month!: number;
 
-  @ApiProperty({ example: 'USD', type: String, enum: CURRENCY_CODES, enumName: 'CurrencyCode' })
+  @ApiPropertyOptional({
+    example: 'USD',
+    type: String,
+    enum: CURRENCY_CODES,
+    enumName: 'CurrencyCode',
+  })
+  @IsOptional()
   @IsInField([...CURRENCY_CODES])
-  currencyCode!: CurrencyCode;
+  currencyCode?: CurrencyCode;
 
   @ApiPropertyOptional({
     example: 'EXPENSE',

--- a/src/modules/transactions-analytics/transactions-analytics.module.ts
+++ b/src/modules/transactions-analytics/transactions-analytics.module.ts
@@ -1,14 +1,11 @@
 import { Module } from '@nestjs/common';
 
-import { CacheModule } from '@/modules/cache/cache.module.js';
-
 import { TransactionsAnalyticsCacheListener } from './transactions-analytics-cache.listener.js';
 import { TransactionsAnalyticsController } from './transactions-analytics.controller.js';
 import { TransactionsAnalyticsRepository } from './transactions-analytics.repository.js';
 import { TransactionsAnalyticsService } from './transactions-analytics.service.js';
 
 @Module({
-  imports: [CacheModule],
   controllers: [TransactionsAnalyticsController],
   providers: [
     TransactionsAnalyticsService,

--- a/src/modules/transactions-analytics/transactions-analytics.repository.ts
+++ b/src/modules/transactions-analytics/transactions-analytics.repository.ts
@@ -12,7 +12,7 @@ import type { Granularity } from './dtos/trends-query.dto.js';
 
 export interface AnalyticsBaseQuery {
   userId: string;
-  currencyCode: CurrencyCode;
+  currencyCode?: CurrencyCode;
   dateFrom: Date;
   dateTo: Date;
   type?: TransactionType;
@@ -203,10 +203,13 @@ export class TransactionsAnalyticsRepository {
   private buildBaseConditions(query: AnalyticsBaseQuery): SQL[] {
     const conditions: SQL[] = [
       eq(transactions.userId, query.userId),
-      eq(transactions.currencyCode, query.currencyCode),
       gte(transactions.date, query.dateFrom),
       lte(transactions.date, query.dateTo),
     ];
+
+    if (query.currencyCode) {
+      conditions.push(eq(transactions.currencyCode, query.currencyCode));
+    }
 
     if (query.type) {
       conditions.push(eq(transactions.type, query.type));

--- a/src/modules/transactions-analytics/transactions-analytics.service.ts
+++ b/src/modules/transactions-analytics/transactions-analytics.service.ts
@@ -24,7 +24,7 @@ const TTL_TRENDS = 600;
 
 interface BaseParams {
   userId: string;
-  currencyCode: CurrencyCode;
+  currencyCode?: CurrencyCode;
   dateFrom?: string;
   dateTo?: string;
   type?: TransactionType;
@@ -41,7 +41,7 @@ interface TopCategoriesParams extends BaseParams {
 
 interface DailySpendingParams {
   userId: string;
-  currencyCode: CurrencyCode;
+  currencyCode?: CurrencyCode;
   year: number;
   month: number;
   type?: TransactionType;

--- a/src/modules/transactions-analytics/transactions-analytics.types.ts
+++ b/src/modules/transactions-analytics/transactions-analytics.types.ts
@@ -8,7 +8,7 @@ export interface SummaryResponse {
   totalExpenses: string;
   netBalance: string;
   transactionCount: number;
-  currencyCode: CurrencyCode;
+  currencyCode?: CurrencyCode;
   dateFrom: string;
   dateTo: string;
 }
@@ -23,7 +23,7 @@ export interface CategoryBreakdownItem {
 }
 
 export interface CategoryBreakdownResponse {
-  currencyCode: CurrencyCode;
+  currencyCode?: CurrencyCode;
   dateFrom: string;
   dateTo: string;
   breakdown: CategoryBreakdownItem[];
@@ -39,7 +39,7 @@ export interface TrendPeriod {
 }
 
 export interface TrendsResponse {
-  currencyCode: CurrencyCode;
+  currencyCode?: CurrencyCode;
   granularity: Granularity;
   periods: TrendPeriod[];
 }
@@ -54,7 +54,7 @@ export interface TopCategoryItem {
 }
 
 export interface TopCategoriesResponse {
-  currencyCode: CurrencyCode;
+  currencyCode?: CurrencyCode;
   categories: TopCategoryItem[];
 }
 
@@ -65,7 +65,7 @@ export interface DailySpendingDay {
 }
 
 export interface DailySpendingResponse {
-  currencyCode: CurrencyCode;
+  currencyCode?: CurrencyCode;
   year: number;
   month: number;
   days: DailySpendingDay[];

--- a/src/modules/transactions/dtos/export-transaction-query.dto.ts
+++ b/src/modules/transactions/dtos/export-transaction-query.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional } from 'class-validator';
 
-import { IsISO8601Field, IsUUIDField } from '@/shared/decorators/validators.js';
+import { IsISO8601Field, IsNotBeforeField, IsUUIDField } from '@/shared/decorators/validators.js';
 
 export const EXPORT_FORMATS = ['json', 'csv'] as const;
 export type ExportFormat = (typeof EXPORT_FORMATS)[number];
@@ -25,6 +25,7 @@ export class ExportTransactionQueryDto {
   @ApiPropertyOptional({ example: '2026-03-31T23:59:59.999+02:00' })
   @IsOptional()
   @IsISO8601Field()
+  @IsNotBeforeField('dateFrom')
   dateTo?: string;
 
   @ApiPropertyOptional({ example: '550e8400-e29b-41d4-a716-446655440000' })

--- a/src/modules/transactions/dtos/transaction-query.dto.ts
+++ b/src/modules/transactions/dtos/transaction-query.dto.ts
@@ -1,7 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional } from 'class-validator';
 
-import { IsISO8601Field, IsUUIDField } from '@/shared/decorators/validators.js';
+import { IsISO8601Field, IsNotBeforeField, IsUUIDField } from '@/shared/decorators/validators.js';
 import { OffsetPaginationDto } from '@/shared/dtos/pagination.dto.js';
 import { CURRENCY_CODES } from '@/shared/enums/currency-code.enum.js';
 import type { CurrencyCode } from '@/shared/enums/currency-code.enum.js';
@@ -46,6 +46,7 @@ export class TransactionQueryDto extends OffsetPaginationDto {
   @ApiPropertyOptional({ example: '2026-03-31T23:59:59.999+02:00' })
   @IsOptional()
   @IsISO8601Field()
+  @IsNotBeforeField('dateFrom')
   dateTo?: string;
 
   @ApiPropertyOptional({

--- a/src/modules/transactions/transactions.module.ts
+++ b/src/modules/transactions/transactions.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 
-import { CacheModule } from '@/modules/cache/cache.module.js';
 import { TransactionCategoriesModule } from '@/modules/transaction-categories/transaction-categories.module.js';
 
 import { TransactionImportService } from './transaction-import.service.js';
@@ -10,7 +9,7 @@ import { TransactionRepository } from './transactions.repository.js';
 import { TransactionsService } from './transactions.service.js';
 
 @Module({
-  imports: [CacheModule, TransactionCategoriesModule],
+  imports: [TransactionCategoriesModule],
   controllers: [TransactionsController],
   providers: [
     TransactionsService,

--- a/src/modules/user/dtos/create-user.dto.ts
+++ b/src/modules/user/dtos/create-user.dto.ts
@@ -14,15 +14,9 @@ import { ROLES } from '@/shared/enums/role.enum.js';
 import type { UserRole } from '@/shared/enums/role.enum.js';
 
 export class CreateUserDto {
-  @ApiProperty({ example: 'John Doe' })
-  @IsStringField()
-  @MinLengthField(1)
-  @MaxLengthField(50)
-  name: string;
-
   @ApiProperty({ example: 'user@example.com' })
   @IsEmailField()
-  email: string;
+  email!: string;
 
   @ApiProperty({ example: 'Pass123456' })
   @IsStringField()
@@ -32,7 +26,21 @@ export class CreateUserDto {
   @MatchesField(/^(?=.*[a-zA-Z])(?=.*\d)/, {
     message: 'Password must contain at least one letter and one digit',
   })
-  password: string;
+  password!: string;
+
+  @ApiPropertyOptional({ example: 'John' })
+  @IsOptional()
+  @IsStringField()
+  @MinLengthField(1)
+  @MaxLengthField(50)
+  firstName?: string;
+
+  @ApiPropertyOptional({ example: 'Doe' })
+  @IsOptional()
+  @IsStringField()
+  @MinLengthField(1)
+  @MaxLengthField(50)
+  lastName?: string;
 
   @ApiPropertyOptional({ example: 'USER', enum: ROLES, enumName: 'UserRole' })
   @IsOptional()

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -9,7 +9,6 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
-  Put,
   Query,
   Request,
   UseGuards,
@@ -80,6 +79,8 @@ export class UserController {
       email: dto.email,
       password: dto.password,
       role: dto.role,
+      firstName: dto.firstName,
+      lastName: dto.lastName,
     });
   }
 
@@ -93,7 +94,7 @@ export class UserController {
     });
   }
 
-  @Put(':id/role')
+  @Patch(':id/role')
   @Roles('ADMIN')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Assign user role (ADMIN only)' })

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -1,13 +1,10 @@
 import { Module } from '@nestjs/common';
 
-import { CacheModule } from '@/modules/cache/cache.module.js';
-
 import { UserController } from './user.controller.js';
 import { UserRepository } from './user.repository.js';
 import { UserService } from './user.service.js';
 
 @Module({
-  imports: [CacheModule],
   controllers: [UserController],
   providers: [UserService, UserRepository],
   exports: [UserService, UserRepository],

--- a/src/shared/decorators/validators.ts
+++ b/src/shared/decorators/validators.ts
@@ -13,8 +13,14 @@ import {
   MaxLength,
   Min,
   MinLength,
+  Validate,
+  ValidatorConstraint,
 } from 'class-validator';
-import type { ValidationOptions } from 'class-validator';
+import type {
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraintInterface,
+} from 'class-validator';
 
 import { ErrorCode } from '../enums/error-code.enum.js';
 
@@ -77,5 +83,33 @@ export function IsBooleanField(options?: ValidationOptions) {
 export function IsISO8601Field(options?: ValidationOptions) {
   return applyDecorators(
     IsISO8601({ strict: true }, { ...options, context: { code: ErrorCode.INVALID_FORMAT } }),
+  );
+}
+
+@ValidatorConstraint({ name: 'isNotBefore', async: false })
+class IsNotBeforeConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, args: ValidationArguments): boolean {
+    const [relatedPropertyName] = args.constraints as [string];
+    const relatedValue = (args.object as Record<string, unknown>)[relatedPropertyName];
+    if (!value || !relatedValue) {
+      return true;
+    }
+
+    return new Date(value as string) >= new Date(relatedValue as string);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const [relatedPropertyName] = args.constraints as [string];
+
+    return `$property must not be before ${relatedPropertyName}`;
+  }
+}
+
+export function IsNotBeforeField(property: string, options?: ValidationOptions) {
+  return applyDecorators(
+    Validate(IsNotBeforeConstraint, [property], {
+      ...options,
+      context: { code: ErrorCode.VALIDATION_ERROR },
+    }),
   );
 }

--- a/src/shared/dtos/list-response.dto.ts
+++ b/src/shared/dtos/list-response.dto.ts
@@ -18,6 +18,9 @@ export class OffsetListResponseDto<T> extends ListResponseDto<T> {
   @ApiProperty({ description: 'Total number of matching records', example: 100 })
   total: number;
 
+  @ApiProperty({ description: 'Total number of pages', example: 5 })
+  totalPages: number;
+
   @ApiProperty({ description: 'Whether more pages are available', example: true })
   hasMore: boolean;
 }


### PR DESCRIPTION
## Summary
- **#17:** Changed `PUT /users/:id/role` to `PATCH` for correct HTTP semantics (partial update, not full replacement)
- **#18:** Renamed `GET /auth/refresh-token` to `GET /auth/refresh-token/info` to resolve path collision with `POST /auth/refresh-token`
- **#19:** Added missing `totalPages` field with `@ApiProperty` to `OffsetListResponseDto` Swagger schema
- **#20:** Made `currencyCode` optional in `AnalyticsQueryDto` and `DailySpendingQueryDto` with corresponding service/repository/type updates
- **#21:** Created `IsNotBeforeField` cross-field validator and applied to `dateTo`/`endDate` in `TransactionQueryDto`, `ExportTransactionQueryDto`, `AnalyticsQueryDto`, and `CreateBudgetDto`
- **#22:** Extracted `AuditLogQueryDto` from controller file to dedicated `dtos/audit-log-query.dto.ts`
- **#23:** Removed redundant `CacheModule` imports from all 7 feature modules (already `@Global()`)
- **#24:** Added `@Throttle({ auth: {} })` to `revoke-refresh-token` and `revoke-refresh-tokens` endpoints
- **#25:** Added `!` definite assignment to `email` and `password` in `RegisterDto` to match project convention
- **#26:** Aligned `CreateUserDto` with `RegisterDto` by replacing `name` field with `firstName`/`lastName`
- **#27:** Added `@IsBooleanField()` validation after `@Transform` on `root` field in `CategoryQueryDto` and `DefaultTransactionCategoryQueryDto`
- **#28:** Replaced inline type casts with imported `AuthUser` type in `AuditLogInterceptor`
- **#29:** Changed `AnyPgColumn` to `import type` in `refresh-tokens.ts` for ESM compatibility

## Test plan
- [ ] Verify `PATCH /users/:id/role` works correctly (was `PUT`)
- [ ] Verify `GET /auth/refresh-token/info` returns token info (renamed from `/auth/refresh-token`)
- [ ] Verify Swagger docs now show `totalPages` in paginated list responses
- [ ] Verify analytics endpoints accept requests without `currencyCode` and return results across all currencies
- [ ] Verify `dateTo < dateFrom` returns 400 validation error on transaction, export, analytics, and budget endpoints
- [ ] Verify `root=maybe` on category query endpoints returns 400 validation error
- [ ] Verify revoke endpoints are rate-limited under the auth throttle band
- [ ] Verify admin user creation accepts `firstName`/`lastName` instead of `name`
- [ ] Run `pnpm check-types` — passes
- [ ] Run `pnpm lint:fix` — passes
- [ ] Run `pnpm format` — passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated responses' totalPages and a reusable "not before" date validation.
  * New audit-log query filters: actor ID, action, and sort options.

* **Improvements**
  * Currency code in analytics made optional to allow multi-currency results.
  * Split user name into first and last name fields.
  * Moved refresh-token info to a new route and added rate limiting to revoke endpoints.
  * Various modules removed redundant cache wiring.

* **Fixes**
  * Tightened request validation and type handling across endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->