### PR TITLE
fix: implement P1/P2 audit findings for type safety, DI, and code quality (#47)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -15,13 +15,10 @@
 | 18b | P1       | Remaining two Redis connections (ioredis vs node-redis mismatch)      | High   | High   | performance-engineer                                    | Todo    |
 | 22  | P1       | Missing partial indexes for `deletedAt IS NULL` queries               | Medium | High   | postgres-pro, database-optimizer                        | Todo    |
 | 23  | P1       | `ilike` search on `description` with no trigram/FTS index             | Medium | High   | postgres-pro, performance-engineer                      | Todo    |
-| 27  | P1       | Widespread `result[0] as T` casts bypassing type safety               | Medium | High   | typescript-pro                                          | Todo    |
-| 28  | P2       | Duplicated category validation logic across 3 services                | Medium | Medium | architect-reviewer                                      | Todo    |
 | 29  | P2       | `CachePort` abstraction exists but is dead code                       | Low    | Medium | architect-reviewer                                      | Todo    |
 | 30  | P2       | ILIKE wildcard not escaped in `UserRepository.findAll`                | Low    | Medium | architect-reviewer, security-auditor                    | Todo    |
 | 31  | P2       | `delByPrefix` uses SCAN + sequential DEL (O(N) Redis)                 | Medium | Medium | architect-reviewer, performance-engineer                | Todo    |
 | 32  | P2       | Export loads 10K rows + JSON.stringify into memory                    | Medium | Medium | architect-reviewer, performance-engineer                | Todo    |
-| 34  | P2       | `loginStatusEnum` in wrong file + lowercase values                    | Low    | Medium | database-optimizer, postgres-pro                        | Todo    |
 | 35  | P2       | Analytics `::date` cast ignores user timezone                         | Medium | Medium | database-optimizer                                      | Todo    |
 | 36  | P2       | `sql.raw` used for granularity string in `getTrends`                  | Low    | Medium | database-optimizer                                      | Todo    |
 | 37  | P2       | Redundant plain index on `RefreshToken.token`                         | Low    | Medium | database-optimizer                                      | Todo    |
@@ -34,11 +31,7 @@
 | 44  | P2       | JWT algorithm not explicitly specified                                | Low    | Medium | security-auditor                                        | Todo    |
 | 45  | P2       | Token blacklist fail-open design (no monitoring)                      | Medium | Medium | security-auditor                                        | Todo    |
 | 46  | P2       | Social auth code exchange race condition (TOCTOU)                     | Medium | Medium | security-auditor                                        | Todo    |
-| 47  | P2       | Unvalidated `token` query param on email verification                 | Low    | Medium | security-auditor                                        | Todo    |
-| 49  | P2       | `UpdateProfileDto` exposes `onboardingCompleted` as user-settable     | Low    | Medium | api-designer                                            | Todo    |
 | 50  | P2       | No `Link` header emitted for paginated responses                      | Medium | Medium | api-designer                                            | Todo    |
-| 51  | P2       | Pagination defaults duplicated at controller and DTO layers           | Low    | Medium | api-designer                                            | Todo    |
-| 52  | P2       | `TimeoutInterceptor` instantiated with `new` bypassing DI             | Low    | Medium | nestjs-expert                                           | Todo    |
 | 53  | P2       | Social callback swallows all errors including programming errors      | Medium | Medium | nestjs-expert                                           | Todo    |
 | 54  | P2       | Health indicators don't extend `HealthIndicator` from Terminus        | Medium | Medium | nestjs-expert                                           | Todo    |
 | 55  | P2       | Redis roundtrip on every authenticated request (blacklist check)      | Medium | Medium | performance-engineer                                    | Todo    |
@@ -165,31 +158,7 @@ PostgreSQL `ALTER TYPE ... ADD VALUE` is non-transactional and cannot be rolled 
 
 ---
 
-#### 27. Widespread `result[0] as T` Casts Bypassing Type Safety
-
-**Effort:** Medium | **Impact:** High | **Reported by:** typescript-pro
-
-14+ occurrences across repositories cast `result[0]` to suppress `T | undefined` from `noUncheckedIndexedAccess`. The cast hides potential undefined access.
-
-**Fix:** Use destructuring: `const [row] = result; if (!row) return null;`
-
-**Files:** Multiple repository files (user, auth, budgets, transaction-categories, recurring-transactions)
-
----
-
 ### P2 -- Medium
-
-#### 28. Duplicated Category Validation Logic Across 3 Services
-
-**Effort:** Medium | **Impact:** Medium | **Reported by:** architect-reviewer
-
-Identical `validateCategory` methods in `TransactionsService`, `RecurringTransactionsService`, and `BudgetsService`.
-
-**Fix:** Extract into `TransactionCategoryService.validateCategoryForTransaction()`.
-
-**Files:** `transactions.service.ts:310-332`, `recurring-transactions.service.ts:472-494`, `budgets.service.ts:293-306`
-
----
 
 #### 29. `CachePort` Abstraction Is Dead Code
 
@@ -236,18 +205,6 @@ Called on every mutation. `SCAN` iterates all keys; `DEL` runs per batch. Gets s
 **Fix:** Use streaming JSON serializer; remove pretty-printing for file downloads.
 
 **Files:** `src/modules/transactions/transactions.repository.ts:96`, `src/modules/transactions/transactions.service.ts:267`
-
----
-
-#### 34. `loginStatusEnum` in Wrong File + Lowercase Values
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** database-optimizer, postgres-pro
-
-Defined in `login-logs.ts` instead of `enums.ts`. Uses lowercase (`'success'`, `'failed'`) while all others use UPPER_CASE.
-
-**Fix:** Move to `enums.ts`, change to `['SUCCESS', 'FAILED']` with migration.
-
-**File:** `src/database/schemas/login-logs.ts:6`
 
 ---
 
@@ -391,30 +348,6 @@ When Redis is down, revoked tokens are accepted. The fail-open design is documen
 
 ---
 
-#### 47. Unvalidated `token` Query Param on Email Verification
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** security-auditor
-
-Raw string passed to DB query without format validation. Token is a UUID.
-
-**Fix:** Add `@Query('token', ParseUUIDPipe)`.
-
-**File:** `src/modules/auth/auth.controller.ts:223`
-
----
-
-#### 49. `UpdateProfileDto` Exposes `onboardingCompleted`
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** api-designer
-
-Any user can mark onboarding as complete via `PATCH /profile`, bypassing the onboarding flow.
-
-**Fix:** Remove `onboardingCompleted` from `UpdateProfileDto`.
-
-**File:** `src/modules/profile/dtos/update-profile.dto.ts:51`
-
----
-
 #### 50. No `Link` Header for Paginated Responses
 
 **Effort:** Medium | **Impact:** Medium | **Reported by:** api-designer
@@ -422,30 +355,6 @@ Any user can mark onboarding as complete via `PATCH /profile`, bypassing the onb
 `Link` is listed in CORS `exposedHeaders` but never emitted. Clients must construct pagination URLs manually.
 
 **File:** `src/app/config/cors.config.ts:6`
-
----
-
-#### 51. Pagination Defaults Duplicated at Controller and DTO Layers
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** api-designer
-
-Every controller has `page: query.page ?? 1` and `pageSize: query.pageSize ?? 20` despite DTO defaults already handling this.
-
-**Fix:** Remove nullish coalescing from controllers; rely on DTO defaults.
-
-**Files:** All paginated controllers
-
----
-
-#### 52. `TimeoutInterceptor` Bypasses DI Container
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** nestjs-expert
-
-Instantiated with `new TimeoutInterceptor(30_000)` instead of via DI. Hardcoded timeout not configurable.
-
-**Fix:** Register as provider, inject timeout from `ConfigService`.
-
-**File:** `src/main.ts:45`
 
 ---
 
@@ -666,52 +575,59 @@ No documentation for required environment variables beyond the Zod schema. Incre
 
 ## Completed Fixes (History)
 
-| #    | Finding                                         | Impact | Effort | Priority | Status |
-| ---- | ----------------------------------------------- | ------ | ------ | -------- | ------ |
-| 1    | Add Helmet security headers                     | 5      | S      | P0       | Done   |
-| 2    | Remove default JWT_SECRET                       | 5      | S      | P0       | Done   |
-| 3    | Fix CORS default to deny all                    | 5      | S      | P0       | Done   |
-| 4    | Enable graceful shutdown hooks                  | 5      | S      | P0       | Done   |
-| 5    | Filter soft-deleted users from login            | 5      | S      | P0       | Done   |
-| 6    | Fix login timing side-channel                   | 4      | S      | P0       | Done   |
-| 7    | Fix N+1 budget overspend cron                   | 5      | M      | P1       | Done   |
-| 8    | Add composite database indexes                  | 5      | S      | P1       | Done   |
-| 9    | Push refresh token filters to SQL               | 4      | S      | P1       | Done   |
-| 10   | Cap export with LIMIT + streaming               | 5      | M      | P1       | Done   |
-| 11   | Replace isDescendantOf with CTE                 | 4      | S      | P1       | Done   |
-| 12   | Rate limiting fail-closed on Redis down         | 5      | M      | P1       | Done   |
-| 13   | Per-endpoint throttling on expensive ops        | 4      | S      | P1       | Done   |
-| 14   | Protect /process endpoint (admin-only)          | 4      | S      | P1       | Done   |
-| 15   | Align admin password policy                     | 4      | S      | P1       | Done   |
-| 16   | Fix service-to-DB architecture violation        | 4      | M      | P1       | Done   |
-| 17   | Add JWT session validation / blacklist          | 5      | L      | P1       | Done   |
-| 18   | Consolidate 3 Redis connections (3→2)           | 4      | M      | P1       | Done   |
-| 19   | Domain events for cache invalidation            | 4      | L      | P2       | Done   |
-| 20   | Extract pagination helper                       | 3      | S      | P2       | Done   |
-| 21   | Remove/complete TransformInterceptor            | 3      | S      | P2       | Done   |
-| 23   | Async CSV parsing                               | 4      | M      | P2       | Done   |
-| 24   | Cache stampede protection                       | 4      | M      | P2       | Done   |
-| 25   | Migrate date columns to timestamptz             | 4      | M      | P2       | Done   |
-| 26   | CSRF protection for cookie auth                 | 4      | M      | P2       | Done   |
-| 27   | Disable Swagger in production                   | 3      | S      | P2       | Done   |
-| 28   | Consistent validator decorators                 | 3      | S      | P2       | Done   |
-| 29   | Add database CHECK constraints                  | 3      | S      | P2       | Done   |
-| 30   | Fix NULLS NOT DISTINCT on unique index          | 3      | S      | P2       | Done   |
-| 31   | Decimal arithmetic for money                    | 4      | M      | P2       | Done   |
-| 32   | HTTP response compression                       | 2      | S      | P3       | Done   |
-| 33   | Add statement_timeout                           | 3      | S      | P3       | Done   |
-| 34   | Sort params on all collections                  | 2      | M      | P3       | Done   |
-| A-2  | No PostgreSQL config in Docker Compose          | 5      | S      | P0       | Done   |
-| A-4  | CSRF token missing from CORS allowedHeaders     | 4      | S      | P1       | Done   |
-| A-5  | Missing CsrfGuard on revoke-refresh-token       | 4      | S      | P1       | Done   |
-| A-6  | CSRF token comparison not timing-safe           | 4      | S      | P1       | Done   |
-| A-12 | Missing index on emailVerificationToken         | 4      | S      | P1       | Done   |
-| A-16 | Throttler auth bypass returns true              | 4      | S      | P1       | Done   |
-| A-19 | findByParentCategory has no LIMIT               | 4      | S      | P1       | Done   |
-| A-20 | Docker PG port exposed on all interfaces        | 4      | S      | P1       | Done   |
-| A-21 | Docker default password in plaintext            | 4      | S      | P1       | Done   |
-| A-25 | AllExceptionsFilter uses @Optional()            | 4      | S      | P1       | Done   |
-| A-60 | sameSite stored as string losing type           | 3      | S      | P2       | Done   |
-| A-7  | AuthService layer violation (UserRepository)    | 4      | M      | P1       | Done   |
-| A-8  | ProfileService layer violation (UserRepository) | 4      | M      | P1       | Done   |
-| A-33 | Excessive constructor params (AuthService)      | 3      | M      | P2       | Done   |
+| #    | Finding                                               | Impact | Effort | Priority | Status |
+| ---- | ----------------------------------------------------- | ------ | ------ | -------- | ------ |
+| 1    | Add Helmet security headers                           | 5      | S      | P0       | Done   |
+| 2    | Remove default JWT_SECRET                             | 5      | S      | P0       | Done   |
+| 3    | Fix CORS default to deny all                          | 5      | S      | P0       | Done   |
+| 4    | Enable graceful shutdown hooks                        | 5      | S      | P0       | Done   |
+| 5    | Filter soft-deleted users from login                  | 5      | S      | P0       | Done   |
+| 6    | Fix login timing side-channel                         | 4      | S      | P0       | Done   |
+| 7    | Fix N+1 budget overspend cron                         | 5      | M      | P1       | Done   |
+| 8    | Add composite database indexes                        | 5      | S      | P1       | Done   |
+| 9    | Push refresh token filters to SQL                     | 4      | S      | P1       | Done   |
+| 10   | Cap export with LIMIT + streaming                     | 5      | M      | P1       | Done   |
+| 11   | Replace isDescendantOf with CTE                       | 4      | S      | P1       | Done   |
+| 12   | Rate limiting fail-closed on Redis down               | 5      | M      | P1       | Done   |
+| 13   | Per-endpoint throttling on expensive ops              | 4      | S      | P1       | Done   |
+| 14   | Protect /process endpoint (admin-only)                | 4      | S      | P1       | Done   |
+| 15   | Align admin password policy                           | 4      | S      | P1       | Done   |
+| 16   | Fix service-to-DB architecture violation              | 4      | M      | P1       | Done   |
+| 17   | Add JWT session validation / blacklist                | 5      | L      | P1       | Done   |
+| 18   | Consolidate 3 Redis connections (3→2)                 | 4      | M      | P1       | Done   |
+| 19   | Domain events for cache invalidation                  | 4      | L      | P2       | Done   |
+| 20   | Extract pagination helper                             | 3      | S      | P2       | Done   |
+| 21   | Remove/complete TransformInterceptor                  | 3      | S      | P2       | Done   |
+| 23   | Async CSV parsing                                     | 4      | M      | P2       | Done   |
+| 24   | Cache stampede protection                             | 4      | M      | P2       | Done   |
+| 25   | Migrate date columns to timestamptz                   | 4      | M      | P2       | Done   |
+| 26   | CSRF protection for cookie auth                       | 4      | M      | P2       | Done   |
+| 27   | Disable Swagger in production                         | 3      | S      | P2       | Done   |
+| 28   | Consistent validator decorators                       | 3      | S      | P2       | Done   |
+| 29   | Add database CHECK constraints                        | 3      | S      | P2       | Done   |
+| 30   | Fix NULLS NOT DISTINCT on unique index                | 3      | S      | P2       | Done   |
+| 31   | Decimal arithmetic for money                          | 4      | M      | P2       | Done   |
+| 32   | HTTP response compression                             | 2      | S      | P3       | Done   |
+| 33   | Add statement_timeout                                 | 3      | S      | P3       | Done   |
+| 34   | Sort params on all collections                        | 2      | M      | P3       | Done   |
+| A-2  | No PostgreSQL config in Docker Compose                | 5      | S      | P0       | Done   |
+| A-4  | CSRF token missing from CORS allowedHeaders           | 4      | S      | P1       | Done   |
+| A-5  | Missing CsrfGuard on revoke-refresh-token             | 4      | S      | P1       | Done   |
+| A-6  | CSRF token comparison not timing-safe                 | 4      | S      | P1       | Done   |
+| A-12 | Missing index on emailVerificationToken               | 4      | S      | P1       | Done   |
+| A-16 | Throttler auth bypass returns true                    | 4      | S      | P1       | Done   |
+| A-19 | findByParentCategory has no LIMIT                     | 4      | S      | P1       | Done   |
+| A-20 | Docker PG port exposed on all interfaces              | 4      | S      | P1       | Done   |
+| A-21 | Docker default password in plaintext                  | 4      | S      | P1       | Done   |
+| A-25 | AllExceptionsFilter uses @Optional()                  | 4      | S      | P1       | Done   |
+| A-60 | sameSite stored as string losing type                 | 3      | S      | P2       | Done   |
+| A-7  | AuthService layer violation (UserRepository)          | 4      | M      | P1       | Done   |
+| A-8  | ProfileService layer violation (UserRepository)       | 4      | M      | P1       | Done   |
+| A-33 | Excessive constructor params (AuthService)            | 3      | M      | P2       | Done   |
+| 27   | Replace `result[0] as T` casts with destructuring     | High   | M      | P1       | Done   |
+| 28   | Extract duplicated category validation                | Medium | M      | P2       | Done   |
+| 34   | Move `loginStatusEnum` to enums.ts + UPPER_CASE       | Medium | S      | P2       | Done   |
+| 47   | Add ParseUUIDPipe to email verification token         | Medium | S      | P2       | Done   |
+| 49   | Remove `onboardingCompleted` from UpdateProfileDto    | Medium | S      | P2       | Done   |
+| 51   | Remove redundant pagination defaults from controllers | Medium | S      | P2       | Done   |
+| 52   | Register TimeoutInterceptor via DI                    | Medium | S      | P2       | Done   |

--- a/drizzle/0015_flaky_butterfly.sql
+++ b/drizzle/0015_flaky_butterfly.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "LoginLog" ALTER COLUMN "status" SET DATA TYPE text;--> statement-breakpoint
+UPDATE "LoginLog" SET "status" = UPPER("status");--> statement-breakpoint
+DROP TYPE "public"."LoginStatus";--> statement-breakpoint
+CREATE TYPE "public"."LoginStatus" AS ENUM('SUCCESS', 'FAILED');--> statement-breakpoint
+ALTER TABLE "LoginLog" ALTER COLUMN "status" SET DATA TYPE "public"."LoginStatus" USING "status"::"public"."LoginStatus";

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,2092 @@
+{
+  "id": "5b5bb302-39a6-43c0-9585-4fd9980c619c",
+  "prevId": "a175b600-ebd0-4d2e-aeb7-f3c7c4c3ef07",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.AuditLog": {
+      "name": "AuditLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AuditLog_actorId_idx": {
+          "name": "AuditLog_actorId_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_action_idx": {
+          "name": "AuditLog_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_createdAt_idx": {
+          "name": "AuditLog_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Budget": {
+      "name": "Budget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "CurrencyCode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "BudgetPeriod",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "BudgetStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Budget_userId_idx": {
+          "name": "Budget_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_categoryId_idx": {
+          "name": "Budget_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_status_idx": {
+          "name": "Budget_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_startDate_endDate_idx": {
+          "name": "Budget_startDate_endDate_idx",
+          "columns": [
+            {
+              "expression": "startDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_status_endDate_idx": {
+          "name": "Budget_status_endDate_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status IN ('ACTIVE', 'EXCEEDED')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Budget_userId_User_id_fk": {
+          "name": "Budget_userId_User_id_fk",
+          "tableFrom": "Budget",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Budget_categoryId_TransactionCategory_id_fk": {
+          "name": "Budget_categoryId_TransactionCategory_id_fk",
+          "tableFrom": "Budget",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["categoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Budget_endDate_after_startDate": {
+          "name": "Budget_endDate_after_startDate",
+          "value": "\"endDate\" > \"startDate\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.DefaultTransactionCategory": {
+      "name": "DefaultTransactionCategory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentDefaultTransactionCategoryId": {
+          "name": "parentDefaultTransactionCategoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "DefaultTransactionCategory_type_idx": {
+          "name": "DefaultTransactionCategory_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DefaultTransactionCategory_parentDefaultTransactionCategoryId_idx": {
+          "name": "DefaultTransactionCategory_parentDefaultTransactionCategoryId_idx",
+          "columns": [
+            {
+              "expression": "parentDefaultTransactionCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DefaultTransactionCategory_parentDefaultTransactionCategoryId_DefaultTransactionCategory_id_fk": {
+          "name": "DefaultTransactionCategory_parentDefaultTransactionCategoryId_DefaultTransactionCategory_id_fk",
+          "tableFrom": "DefaultTransactionCategory",
+          "tableTo": "DefaultTransactionCategory",
+          "columnsFrom": ["parentDefaultTransactionCategoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "DefaultTransactionCategory_name_type_parentDefaultTransactionCategoryId_key": {
+          "name": "DefaultTransactionCategory_name_type_parentDefaultTransactionCategoryId_key",
+          "nullsNotDistinct": true,
+          "columns": ["name", "type", "parentDefaultTransactionCategoryId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KnownDevice": {
+      "name": "KnownDevice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstSeenAt": {
+          "name": "firstSeenAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "KnownDevice_userId_User_id_fk": {
+          "name": "KnownDevice_userId_User_id_fk",
+          "tableFrom": "KnownDevice",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "KnownDevice_userId_ipAddress_userAgent_unique": {
+          "name": "KnownDevice_userId_ipAddress_userAgent_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userId", "ipAddress", "userAgent"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LoginLog": {
+      "name": "LoginLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "LoginStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failReason": {
+          "name": "failReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LoginLog_userId_idx": {
+          "name": "LoginLog_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LoginLog_createdAt_idx": {
+          "name": "LoginLog_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LoginLog_userId_User_id_fk": {
+          "name": "LoginLog_userId_User_id_fk",
+          "tableFrom": "LoginLog",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecurringTransaction": {
+      "name": "RecurringTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "CurrencyCode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "RecurringFrequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextOccurrenceDate": {
+          "name": "nextOccurrenceDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "RecurringTransactionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RecurringTransaction_userId_idx": {
+          "name": "RecurringTransaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_categoryId_idx": {
+          "name": "RecurringTransaction_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_status_idx": {
+          "name": "RecurringTransaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_nextOccurrenceDate_idx": {
+          "name": "RecurringTransaction_nextOccurrenceDate_idx",
+          "columns": [
+            {
+              "expression": "nextOccurrenceDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_type_idx": {
+          "name": "RecurringTransaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecurringTransaction_userId_User_id_fk": {
+          "name": "RecurringTransaction_userId_User_id_fk",
+          "tableFrom": "RecurringTransaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RecurringTransaction_userId_categoryId_TransactionCategory_userId_id_fk": {
+          "name": "RecurringTransaction_userId_categoryId_TransactionCategory_userId_id_fk",
+          "tableFrom": "RecurringTransaction",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["userId", "categoryId"],
+          "columnsTo": ["userId", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "RecurringTransaction_interval_gt_0_chk": {
+          "name": "RecurringTransaction_interval_gt_0_chk",
+          "value": "\"RecurringTransaction\".\"interval\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.RefreshToken": {
+      "name": "RefreshToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceInfo": {
+          "name": "deviceInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RefreshToken_userId_idx": {
+          "name": "RefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RefreshToken_expiresAt_idx": {
+          "name": "RefreshToken_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RefreshToken_userId_User_id_fk": {
+          "name": "RefreshToken_userId_User_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RefreshToken_replacedByTokenId_RefreshToken_id_fk": {
+          "name": "RefreshToken_replacedByTokenId_RefreshToken_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "RefreshToken",
+          "columnsFrom": ["replacedByTokenId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "RefreshToken_token_unique": {
+          "name": "RefreshToken_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        },
+        "RefreshToken_replacedByTokenId_unique": {
+          "name": "RefreshToken_replacedByTokenId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["replacedByTokenId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TransactionCategory": {
+      "name": "TransactionCategory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentCategoryId": {
+          "name": "parentCategoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TransactionCategory_userId_idx": {
+          "name": "TransactionCategory_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_parentCategoryId_idx": {
+          "name": "TransactionCategory_parentCategoryId_idx",
+          "columns": [
+            {
+              "expression": "parentCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_type_idx": {
+          "name": "TransactionCategory_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TransactionCategory_userId_User_id_fk": {
+          "name": "TransactionCategory_userId_User_id_fk",
+          "tableFrom": "TransactionCategory",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "TransactionCategory_parentCategoryId_TransactionCategory_id_fk": {
+          "name": "TransactionCategory_parentCategoryId_TransactionCategory_id_fk",
+          "tableFrom": "TransactionCategory",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["parentCategoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "TransactionCategory_userId_name_type_parentCategoryId_key": {
+          "name": "TransactionCategory_userId_name_type_parentCategoryId_key",
+          "nullsNotDistinct": true,
+          "columns": ["userId", "name", "type", "parentCategoryId"]
+        },
+        "TransactionCategory_userId_id_key": {
+          "name": "TransactionCategory_userId_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["userId", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Transaction": {
+      "name": "Transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "CurrencyCode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurringTransactionId": {
+          "name": "recurringTransactionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Transaction_userId_idx": {
+          "name": "Transaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_categoryId_idx": {
+          "name": "Transaction_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_date_idx": {
+          "name": "Transaction_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_type_idx": {
+          "name": "Transaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_currencyCode_idx": {
+          "name": "Transaction_currencyCode_idx",
+          "columns": [
+            {
+              "expression": "currencyCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_recurringTransactionId_idx": {
+          "name": "Transaction_recurringTransactionId_idx",
+          "columns": [
+            {
+              "expression": "recurringTransactionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_userId_date_idx": {
+          "name": "Transaction_userId_date_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_userId_currencyCode_date_idx": {
+          "name": "Transaction_userId_currencyCode_date_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currencyCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Transaction_userId_User_id_fk": {
+          "name": "Transaction_userId_User_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Transaction_recurringTransactionId_RecurringTransaction_id_fk": {
+          "name": "Transaction_recurringTransactionId_RecurringTransaction_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "RecurringTransaction",
+          "columnsFrom": ["recurringTransactionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "Transaction_userId_categoryId_TransactionCategory_userId_id_fk": {
+          "name": "Transaction_userId_categoryId_TransactionCategory_userId_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["userId", "categoryId"],
+          "columnsTo": ["userId", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Transaction_amount_positive": {
+          "name": "Transaction_amount_positive",
+          "value": "amount > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authProvider": {
+          "name": "authProvider",
+          "type": "AuthProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'LOCAL'"
+        },
+        "authProviderId": {
+          "name": "authProviderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "emailVerificationToken": {
+          "name": "emailVerificationToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerificationTokenExpiresAt": {
+          "name": "emailVerificationTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "countryCode": {
+          "name": "countryCode",
+          "type": "CountryCode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseCurrencyCode": {
+          "name": "baseCurrencyCode",
+          "type": "CurrencyCode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingCompleted": {
+          "name": "onboardingCompleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "User_authProvider_authProviderId_unique": {
+          "name": "User_authProvider_authProviderId_unique",
+          "columns": [
+            {
+              "expression": "authProvider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "authProviderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"User\".\"authProviderId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_emailVerificationToken_idx": {
+          "name": "User_emailVerificationToken_idx",
+          "columns": [
+            {
+              "expression": "emailVerificationToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"User\".\"emailVerificationToken\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "User_email_unique": {
+          "name": "User_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Verification": {
+      "name": "Verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Verification_identifier_idx": {
+          "name": "Verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AuthProvider": {
+      "name": "AuthProvider",
+      "schema": "public",
+      "values": ["LOCAL", "GOOGLE", "GITHUB"]
+    },
+    "public.BudgetPeriod": {
+      "name": "BudgetPeriod",
+      "schema": "public",
+      "values": ["WEEKLY", "MONTHLY", "QUARTERLY", "YEARLY", "CUSTOM"]
+    },
+    "public.BudgetStatus": {
+      "name": "BudgetStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "EXCEEDED"]
+    },
+    "public.CountryCode": {
+      "name": "CountryCode",
+      "schema": "public",
+      "values": [
+        "AD",
+        "AE",
+        "AF",
+        "AG",
+        "AI",
+        "AL",
+        "AM",
+        "AO",
+        "AQ",
+        "AR",
+        "AS",
+        "AT",
+        "AU",
+        "AW",
+        "AX",
+        "AZ",
+        "BA",
+        "BB",
+        "BD",
+        "BE",
+        "BF",
+        "BG",
+        "BH",
+        "BI",
+        "BJ",
+        "BL",
+        "BM",
+        "BN",
+        "BO",
+        "BQ",
+        "BR",
+        "BS",
+        "BT",
+        "BV",
+        "BW",
+        "BY",
+        "BZ",
+        "CA",
+        "CC",
+        "CD",
+        "CF",
+        "CG",
+        "CH",
+        "CI",
+        "CK",
+        "CL",
+        "CM",
+        "CN",
+        "CO",
+        "CR",
+        "CU",
+        "CV",
+        "CW",
+        "CX",
+        "CY",
+        "CZ",
+        "DE",
+        "DJ",
+        "DK",
+        "DM",
+        "DO",
+        "DZ",
+        "EC",
+        "EE",
+        "EG",
+        "EH",
+        "ER",
+        "ES",
+        "ET",
+        "FI",
+        "FJ",
+        "FK",
+        "FM",
+        "FO",
+        "FR",
+        "GA",
+        "GB",
+        "GD",
+        "GE",
+        "GF",
+        "GG",
+        "GH",
+        "GI",
+        "GL",
+        "GM",
+        "GN",
+        "GP",
+        "GQ",
+        "GR",
+        "GS",
+        "GT",
+        "GU",
+        "GW",
+        "GY",
+        "HK",
+        "HM",
+        "HN",
+        "HR",
+        "HT",
+        "HU",
+        "ID",
+        "IE",
+        "IL",
+        "IM",
+        "IN",
+        "IO",
+        "IQ",
+        "IR",
+        "IS",
+        "IT",
+        "JE",
+        "JM",
+        "JO",
+        "JP",
+        "KE",
+        "KG",
+        "KH",
+        "KI",
+        "KM",
+        "KN",
+        "KP",
+        "KR",
+        "KW",
+        "KY",
+        "KZ",
+        "LA",
+        "LB",
+        "LC",
+        "LI",
+        "LK",
+        "LR",
+        "LS",
+        "LT",
+        "LU",
+        "LV",
+        "LY",
+        "MA",
+        "MC",
+        "MD",
+        "ME",
+        "MF",
+        "MG",
+        "MH",
+        "MK",
+        "ML",
+        "MM",
+        "MN",
+        "MO",
+        "MP",
+        "MQ",
+        "MR",
+        "MS",
+        "MT",
+        "MU",
+        "MV",
+        "MW",
+        "MX",
+        "MY",
+        "MZ",
+        "NA",
+        "NC",
+        "NE",
+        "NF",
+        "NG",
+        "NI",
+        "NL",
+        "NO",
+        "NP",
+        "NR",
+        "NU",
+        "NZ",
+        "OM",
+        "PA",
+        "PE",
+        "PF",
+        "PG",
+        "PH",
+        "PK",
+        "PL",
+        "PM",
+        "PN",
+        "PR",
+        "PS",
+        "PT",
+        "PW",
+        "PY",
+        "QA",
+        "RE",
+        "RO",
+        "RS",
+        "RU",
+        "RW",
+        "SA",
+        "SB",
+        "SC",
+        "SD",
+        "SE",
+        "SG",
+        "SH",
+        "SI",
+        "SJ",
+        "SK",
+        "SL",
+        "SM",
+        "SN",
+        "SO",
+        "SR",
+        "SS",
+        "ST",
+        "SV",
+        "SX",
+        "SY",
+        "SZ",
+        "TC",
+        "TD",
+        "TF",
+        "TG",
+        "TH",
+        "TJ",
+        "TK",
+        "TL",
+        "TM",
+        "TN",
+        "TO",
+        "TR",
+        "TT",
+        "TV",
+        "TW",
+        "TZ",
+        "UA",
+        "UG",
+        "UM",
+        "US",
+        "UY",
+        "UZ",
+        "VA",
+        "VC",
+        "VE",
+        "VG",
+        "VI",
+        "VN",
+        "VU",
+        "WF",
+        "WS",
+        "YE",
+        "YT",
+        "ZA",
+        "ZM",
+        "ZW"
+      ]
+    },
+    "public.CurrencyCode": {
+      "name": "CurrencyCode",
+      "schema": "public",
+      "values": [
+        "AED",
+        "AFN",
+        "ALL",
+        "AMD",
+        "ANG",
+        "AOA",
+        "ARS",
+        "AUD",
+        "AWG",
+        "AZN",
+        "BAM",
+        "BBD",
+        "BDT",
+        "BGN",
+        "BHD",
+        "BIF",
+        "BMD",
+        "BND",
+        "BOB",
+        "BRL",
+        "BSD",
+        "BTN",
+        "BWP",
+        "BYN",
+        "BZD",
+        "CAD",
+        "CDF",
+        "CHF",
+        "CLP",
+        "CNY",
+        "COP",
+        "CRC",
+        "CUP",
+        "CVE",
+        "CZK",
+        "DJF",
+        "DKK",
+        "DOP",
+        "DZD",
+        "EGP",
+        "ERN",
+        "ETB",
+        "EUR",
+        "FJD",
+        "FKP",
+        "GBP",
+        "GEL",
+        "GHS",
+        "GIP",
+        "GMD",
+        "GNF",
+        "GTQ",
+        "GYD",
+        "HKD",
+        "HNL",
+        "HRK",
+        "HTG",
+        "HUF",
+        "IDR",
+        "ILS",
+        "INR",
+        "IQD",
+        "IRR",
+        "ISK",
+        "JMD",
+        "JOD",
+        "JPY",
+        "KES",
+        "KGS",
+        "KHR",
+        "KMF",
+        "KPW",
+        "KRW",
+        "KWD",
+        "KYD",
+        "KZT",
+        "LAK",
+        "LBP",
+        "LKR",
+        "LRD",
+        "LSL",
+        "LYD",
+        "MAD",
+        "MDL",
+        "MGA",
+        "MKD",
+        "MMK",
+        "MNT",
+        "MOP",
+        "MRU",
+        "MUR",
+        "MVR",
+        "MWK",
+        "MXN",
+        "MYR",
+        "MZN",
+        "NAD",
+        "NGN",
+        "NIO",
+        "NOK",
+        "NPR",
+        "NZD",
+        "OMR",
+        "PAB",
+        "PEN",
+        "PGK",
+        "PHP",
+        "PKR",
+        "PLN",
+        "PYG",
+        "QAR",
+        "RON",
+        "RSD",
+        "RUB",
+        "RWF",
+        "SAR",
+        "SBD",
+        "SCR",
+        "SDG",
+        "SEK",
+        "SGD",
+        "SHP",
+        "SLE",
+        "SLL",
+        "SOS",
+        "SRD",
+        "SSP",
+        "STN",
+        "SYP",
+        "SZL",
+        "THB",
+        "TJS",
+        "TMT",
+        "TND",
+        "TOP",
+        "TRY",
+        "TTD",
+        "TWD",
+        "TZS",
+        "UAH",
+        "UGX",
+        "USD",
+        "UYU",
+        "UZS",
+        "VES",
+        "VND",
+        "VUV",
+        "WST",
+        "XAF",
+        "XCD",
+        "XDR",
+        "XOF",
+        "XPF",
+        "YER",
+        "ZAR",
+        "ZMW",
+        "ZWL"
+      ]
+    },
+    "public.LoginStatus": {
+      "name": "LoginStatus",
+      "schema": "public",
+      "values": ["SUCCESS", "FAILED"]
+    },
+    "public.RecurringFrequency": {
+      "name": "RecurringFrequency",
+      "schema": "public",
+      "values": ["DAILY", "WEEKLY", "MONTHLY", "YEARLY"]
+    },
+    "public.RecurringTransactionStatus": {
+      "name": "RecurringTransactionStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "PAUSED", "CANCELLED"]
+    },
+    "public.TransactionType": {
+      "name": "TransactionType",
+      "schema": "public",
+      "values": ["EXPENSE", "INCOME"]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": ["USER", "ADMIN", "SUPER_ADMIN"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1775795286501,
       "tag": "0014_demonic_franklin_richards",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1775806394156,
+      "tag": "0015_flaky_butterfly",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { AllExceptionsFilter } from './app/filters/all-exceptions.filter.js';
 import { ProblemDetailsFilter } from './app/filters/problem-details.filter.js';
 import { HealthModule } from './app/health/health.module.js';
 import { RequestContextInterceptor } from './app/interceptors/request-context.interceptor.js';
+import { TimeoutInterceptor } from './app/interceptors/timeout.interceptor.js';
 import { AppThrottlerGuard } from './app/throttler/app-throttler.guard.js';
 import { RedisThrottlerStorage } from './app/throttler/redis-throttler.storage.js';
 import { ThrottlerStorageModule } from './app/throttler/throttler-storage.module.js';
@@ -88,6 +89,7 @@ import { UserModule } from './modules/user/user.module.js';
     AllExceptionsFilter,
     ProblemDetailsFilter,
     RequestContextInterceptor,
+    TimeoutInterceptor,
     {
       provide: APP_INTERCEPTOR,
       useClass: AuditLogInterceptor,

--- a/src/app/config/env.schema.ts
+++ b/src/app/config/env.schema.ts
@@ -140,6 +140,14 @@ export const envSchema = z
     SMTP_FROM: z.string().min(1).optional(),
 
     EMAIL_VERIFICATION_REDIRECT_URL: z.url().optional(),
+
+    REQUEST_TIMEOUT_MS: z
+      .string()
+      .default('30000')
+      .transform((value) => Number.parseInt(value, 10))
+      .refine((value) => value > 0, {
+        message: 'REQUEST_TIMEOUT_MS must be greater than 0',
+      }),
   })
   .refine(
     (env) => {

--- a/src/app/interceptors/timeout.interceptor.ts
+++ b/src/app/interceptors/timeout.interceptor.ts
@@ -1,15 +1,18 @@
 import { Injectable, RequestTimeoutException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { throwError, TimeoutError } from 'rxjs';
 import { catchError, timeout } from 'rxjs/operators';
 import type { NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
 import type { Observable } from 'rxjs';
 
+import type { Env } from '@/app/config/env.schema.js';
+
 @Injectable()
 export class TimeoutInterceptor implements NestInterceptor {
   private readonly timeoutMs: number;
 
-  constructor(timeoutMs = 30_000) {
-    this.timeoutMs = timeoutMs;
+  constructor(configService: ConfigService<Env, true>) {
+    this.timeoutMs = configService.get('REQUEST_TIMEOUT_MS', { infer: true });
   }
 
   intercept(_context: ExecutionContext, next: CallHandler): Observable<unknown> {

--- a/src/database/schemas/enums.ts
+++ b/src/database/schemas/enums.ts
@@ -281,6 +281,8 @@ export const budgetPeriodEnum = pgEnum('BudgetPeriod', [
 
 export const budgetStatusEnum = pgEnum('BudgetStatus', ['ACTIVE', 'EXCEEDED']);
 
+export const loginStatusEnum = pgEnum('LoginStatus', ['SUCCESS', 'FAILED']);
+
 export const currencyCodeEnum = pgEnum('CurrencyCode', [
   'AED',
   'AFN',

--- a/src/database/schemas/login-logs.ts
+++ b/src/database/schemas/login-logs.ts
@@ -1,8 +1,7 @@
-import { index, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { index, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 
+import { loginStatusEnum } from './enums.js';
 import { users } from './users.js';
-
-export const loginStatusEnum = pgEnum('LoginStatus', ['success', 'failed']);
 
 export const loginLogs = pgTable(
   'LoginLog',

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ async function bootstrap() {
 
   app.useGlobalFilters(app.get(ProblemDetailsFilter), app.get(AllExceptionsFilter));
 
-  app.useGlobalInterceptors(app.get(RequestContextInterceptor), new TimeoutInterceptor(30_000));
+  app.useGlobalInterceptors(app.get(RequestContextInterceptor), app.get(TimeoutInterceptor));
 
   app.useGlobalPipes(createValidationPipe());
 

--- a/src/modules/audit-log/audit-log.controller.ts
+++ b/src/modules/audit-log/audit-log.controller.ts
@@ -24,8 +24,8 @@ export class AuditLogController {
   @ApiResponse({ status: 200, type: AuditLogListResponseDto })
   async findAll(@Query() query: AuditLogQueryDto) {
     const result = await this.auditLogService.findAll({
-      page: query.page ?? 1,
-      pageSize: query.pageSize ?? 20,
+      page: query.page,
+      pageSize: query.pageSize,
       actorId: query.actorId,
       action: query.action,
       sortBy: query.sortBy,

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import {
   HttpCode,
   InternalServerErrorException,
   Logger,
+  ParseUUIDPipe,
   Post,
   Query,
   Request,
@@ -226,22 +227,16 @@ export class AuthController {
   @Get('verify-email')
   @ApiOperation({ summary: 'Verify email address via token' })
   @ApiResponse({ status: 302, description: 'Redirects to frontend with result' })
-  async verifyEmail(@Query('token') token: string, @Res() res: Response): Promise<void> {
+  async verifyEmail(
+    @Query('token', ParseUUIDPipe) token: string,
+    @Res() res: Response,
+  ): Promise<void> {
     const redirectUrl =
       this.configService.get('EMAIL_VERIFICATION_REDIRECT_URL', { infer: true }) ??
       this.socialAuthRedirectUrl;
 
     if (!redirectUrl) {
       throw new InternalServerErrorException('Email verification redirect URL is not configured');
-    }
-
-    if (!token) {
-      const url = new URL(redirectUrl);
-      url.searchParams.set('status', 'error');
-      url.searchParams.set('error', 'invalid_token');
-      res.redirect(url.toString());
-
-      return;
     }
 
     const result = await this.authService.verifyEmail(token);

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -89,7 +89,7 @@ export class AuthService {
       await bcrypt.compare(password, AuthService.DUMMY_HASH);
       void this.loginLogRepo.create({
         email,
-        status: 'failed',
+        status: 'FAILED',
         ipAddress: deviceContext?.ipAddress,
         userAgent: deviceContext?.userAgent,
         failReason: 'user_not_found',
@@ -104,7 +104,7 @@ export class AuthService {
       void this.loginLogRepo.create({
         userId: user.id,
         email,
-        status: 'failed',
+        status: 'FAILED',
         ipAddress: deviceContext?.ipAddress,
         userAgent: deviceContext?.userAgent,
         failReason: 'social_account',
@@ -120,7 +120,7 @@ export class AuthService {
       void this.loginLogRepo.create({
         userId: user.id,
         email,
-        status: 'failed',
+        status: 'FAILED',
         ipAddress: deviceContext?.ipAddress,
         userAgent: deviceContext?.userAgent,
         failReason: 'invalid_password',
@@ -134,7 +134,7 @@ export class AuthService {
     void this.loginLogRepo.create({
       userId: user.id,
       email,
-      status: 'success',
+      status: 'SUCCESS',
       ipAddress: deviceContext?.ipAddress,
       userAgent: deviceContext?.userAgent,
     });
@@ -155,7 +155,7 @@ export class AuthService {
       void this.loginLogRepo.create({
         userId: existingByProvider.id,
         email: existingByProvider.email,
-        status: 'success',
+        status: 'SUCCESS',
         ipAddress: deviceContext?.ipAddress,
         userAgent: deviceContext?.userAgent,
       });
@@ -175,7 +175,7 @@ export class AuthService {
       void this.loginLogRepo.create({
         userId: existingByEmail.id,
         email,
-        status: 'failed',
+        status: 'FAILED',
         ipAddress: deviceContext?.ipAddress,
         userAgent: deviceContext?.userAgent,
         failReason: 'email_already_exists',
@@ -210,7 +210,7 @@ export class AuthService {
     void this.loginLogRepo.create({
       userId: newUser.id,
       email: newUser.email,
-      status: 'success',
+      status: 'SUCCESS',
       ipAddress: deviceContext?.ipAddress,
       userAgent: deviceContext?.userAgent,
     });

--- a/src/modules/auth/login-log.repository.ts
+++ b/src/modules/auth/login-log.repository.ts
@@ -7,7 +7,7 @@ import type { DrizzleDb } from '@/database/types.js';
 export interface LoginLogEntry {
   userId?: string;
   email: string;
-  status: 'success' | 'failed';
+  status: 'SUCCESS' | 'FAILED';
   ipAddress?: string;
   userAgent?: string;
   failReason?: string;

--- a/src/modules/budgets/budgets.controller.ts
+++ b/src/modules/budgets/budgets.controller.ts
@@ -42,8 +42,8 @@ export class BudgetsController {
   async findAll(@Query() query: BudgetQueryDto, @Request() req: AuthenticatedRequest) {
     const result = await this.budgetsService.findAll({
       userId: req.user.id,
-      page: query.page ?? 1,
-      pageSize: query.pageSize ?? 20,
+      page: query.page,
+      pageSize: query.pageSize,
       status: query.status,
       period: query.period,
       categoryId: query.categoryId,

--- a/src/modules/budgets/budgets.repository.ts
+++ b/src/modules/budgets/budgets.repository.ts
@@ -139,16 +139,17 @@ export class BudgetRepository {
       .where(and(eq(budgets.id, id), eq(budgets.userId, userId)))
       .limit(1);
 
-    if (result.length === 0) {
+    const [row] = result;
+    if (!row) {
       return null;
     }
 
-    return this.toBudgetInfo(result[0] as typeof budgets.$inferSelect);
+    return this.toBudgetInfo(row);
   }
 
   async create(data: CreateBudgetData, tx?: DrizzleDb): Promise<BudgetInfo> {
     const db = tx ?? this.db;
-    const [budget] = await db
+    const result = await db
       .insert(budgets)
       .values({
         userId: data.userId,
@@ -162,7 +163,12 @@ export class BudgetRepository {
       })
       .returning();
 
-    return this.toBudgetInfo(budget as typeof budgets.$inferSelect);
+    const [row] = result;
+    if (!row) {
+      throw new Error('Insert did not return a row');
+    }
+
+    return this.toBudgetInfo(row);
   }
 
   async update(params: {
@@ -197,11 +203,12 @@ export class BudgetRepository {
       .where(and(eq(budgets.id, id), eq(budgets.userId, userId)))
       .returning();
 
-    if (result.length === 0) {
+    const [row] = result;
+    if (!row) {
       return null;
     }
 
-    return this.toBudgetInfo(result[0] as typeof budgets.$inferSelect);
+    return this.toBudgetInfo(row);
   }
 
   async delete(id: string, userId: string): Promise<boolean> {
@@ -248,11 +255,12 @@ export class BudgetRepository {
       .where(and(...conditions))
       .limit(1);
 
-    if (result.length === 0) {
+    const [row] = result;
+    if (!row) {
       return null;
     }
 
-    return this.toBudgetInfo(result[0] as typeof budgets.$inferSelect);
+    return this.toBudgetInfo(row);
   }
 
   async getSpentAmount(params: {

--- a/src/modules/budgets/budgets.service.ts
+++ b/src/modules/budgets/budgets.service.ts
@@ -9,7 +9,7 @@ import { Decimal } from 'decimal.js';
 import type { DrizzleDb } from '@/database/types.js';
 import { buildCacheKey, buildCachePrefix } from '@/modules/cache/cache-key.utils.js';
 import { CacheService } from '@/modules/cache/cache.service.js';
-import { TransactionCategoryRepository } from '@/modules/transaction-categories/transaction-categories.repository.js';
+import { TransactionCategoriesService } from '@/modules/transaction-categories/transaction-categories.service.js';
 import { ErrorCode } from '@/shared/enums/error-code.enum.js';
 import type { BudgetPeriod, BudgetStatus } from '@/shared/enums/budget.enum.js';
 import type { CurrencyCode } from '@/shared/enums/currency-code.enum.js';
@@ -46,7 +46,7 @@ export interface BudgetProgress {
 export class BudgetsService {
   constructor(
     private readonly budgetRepository: BudgetRepository,
-    private readonly categoryRepository: TransactionCategoryRepository,
+    private readonly categoriesService: TransactionCategoriesService,
     private readonly cacheService: CacheService,
   ) {}
 
@@ -95,7 +95,11 @@ export class BudgetsService {
 
     const result = await this.budgetRepository.transaction(async (tx) => {
       if (data.categoryId) {
-        await this.validateCategory(data.categoryId, data.userId, tx);
+        await this.categoriesService.validateCategoryForTransaction({
+          categoryId: data.categoryId,
+          userId: data.userId,
+          tx,
+        });
       }
 
       await this.checkOverlap({
@@ -135,7 +139,11 @@ export class BudgetsService {
 
       if (data.categoryId !== undefined) {
         if (data.categoryId !== null) {
-          await this.validateCategory(data.categoryId, userId, tx);
+          await this.categoriesService.validateCategoryForTransaction({
+            categoryId: data.categoryId,
+            userId,
+            tx,
+          });
         }
       }
 
@@ -287,21 +295,6 @@ export class BudgetsService {
         return new Date(year + 1, month + 1, 0);
       default:
         return new Date(startDate);
-    }
-  }
-
-  private async validateCategory(
-    categoryId: string,
-    userId: string,
-    tx?: DrizzleDb,
-  ): Promise<void> {
-    const category = await this.categoryRepository.findForValidation(categoryId, userId, tx);
-
-    if (!category) {
-      throw new NotFoundException({
-        code: ErrorCode.RESOURCE_NOT_FOUND,
-        message: `Category ${categoryId} not found`,
-      });
     }
   }
 

--- a/src/modules/default-transaction-categories/default-transaction-categories.controller.ts
+++ b/src/modules/default-transaction-categories/default-transaction-categories.controller.ts
@@ -41,8 +41,8 @@ export class DefaultTransactionCategoriesController {
   @ApiResponse({ status: 200, type: DefaultTransactionCategoryListResponseDto })
   async findAll(@Query() query: DefaultTransactionCategoryQueryDto) {
     const result = await this.service.findAll({
-      page: query.page ?? 1,
-      pageSize: query.pageSize ?? 20,
+      page: query.page,
+      pageSize: query.pageSize,
       type: query.type,
       root: query.root,
       sortBy: query.sortBy,

--- a/src/modules/default-transaction-categories/default-transaction-categories.repository.ts
+++ b/src/modules/default-transaction-categories/default-transaction-categories.repository.ts
@@ -103,13 +103,12 @@ export class DefaultTransactionCategoryRepository {
       )
       .limit(1);
 
-    if (result.length === 0) {
+    const [row] = result;
+    if (!row) {
       return null;
     }
 
-    return this.toDefaultCategoryInfo(
-      result[0] as typeof defaultTransactionCategories.$inferSelect,
-    );
+    return this.toDefaultCategoryInfo(row);
   }
 
   async findAllActive(tx?: DrizzleDb): Promise<DefaultCategoryInfo[]> {
@@ -129,7 +128,7 @@ export class DefaultTransactionCategoryRepository {
 
   async create(data: CreateDefaultCategoryData, tx?: DrizzleDb): Promise<DefaultCategoryInfo> {
     const db = tx ?? this.db;
-    const [category] = await db
+    const result = await db
       .insert(defaultTransactionCategories)
       .values({
         name: data.name,
@@ -138,7 +137,12 @@ export class DefaultTransactionCategoryRepository {
       })
       .returning();
 
-    return this.toDefaultCategoryInfo(category as typeof defaultTransactionCategories.$inferSelect);
+    const [row] = result;
+    if (!row) {
+      throw new Error('Insert did not return a row');
+    }
+
+    return this.toDefaultCategoryInfo(row);
   }
 
   async update(params: {
@@ -169,13 +173,12 @@ export class DefaultTransactionCategoryRepository {
       )
       .returning();
 
-    if (result.length === 0) {
+    const [row] = result;
+    if (!row) {
       return null;
     }
 
-    return this.toDefaultCategoryInfo(
-      result[0] as typeof defaultTransactionCategories.$inferSelect,
-    );
+    return this.toDefaultCategoryInfo(row);
   }
 
   async softDelete(id: string, tx?: DrizzleDb): Promise<boolean> {

--- a/src/modules/onboarding/dtos/complete-onboarding.dto.ts
+++ b/src/modules/onboarding/dtos/complete-onboarding.dto.ts
@@ -9,14 +9,14 @@ import {
   MaxLengthField,
   MinLengthField,
 } from '@/shared/decorators/validators.js';
-import { CURRENCY_CODES } from '@/shared/enums/currency-code.enum.js';
+import { CURRENCY_CODES, type CurrencyCode } from '@/shared/enums/currency-code.enum.js';
 
 export class CompleteOnboardingDto {
   @ApiProperty({ example: 'USD' })
   @IsStringField()
   @IsNotEmptyField({ message: 'baseCurrencyCode is required' })
   @IsInField([...CURRENCY_CODES], { message: 'Invalid currency code' })
-  baseCurrencyCode!: string;
+  baseCurrencyCode!: CurrencyCode;
 
   @ApiPropertyOptional({ example: 'Pass123456' })
   @IsOptional()

--- a/src/modules/onboarding/onboarding.service.ts
+++ b/src/modules/onboarding/onboarding.service.ts
@@ -3,7 +3,6 @@ import * as bcrypt from 'bcrypt';
 
 import { BCRYPT_ROUNDS } from '@/shared/constants/auth.constants.js';
 import { ErrorCode } from '@/shared/enums/error-code.enum.js';
-import type { CurrencyCode } from '@/shared/enums/currency-code.enum.js';
 
 import { UserService } from '../user/user.service.js';
 import { TransactionCategoryRepository } from '../transaction-categories/transaction-categories.repository.js';
@@ -65,7 +64,7 @@ export class OnboardingService {
     }
 
     await this.userService.updateProfile(userId, {
-      baseCurrencyCode: dto.baseCurrencyCode as CurrencyCode,
+      baseCurrencyCode: dto.baseCurrencyCode,
       onboardingCompleted: true,
     });
 

--- a/src/modules/profile/dtos/update-profile.dto.ts
+++ b/src/modules/profile/dtos/update-profile.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsBoolean } from 'class-validator';
+import { IsOptional } from 'class-validator';
 
 import {
   IsInField,
@@ -46,9 +46,4 @@ export class UpdateProfileDto {
   @IsOptional()
   @IsInField(CURRENCY_CODES)
   baseCurrencyCode?: CurrencyCode;
-
-  @ApiPropertyOptional({ description: 'Whether the user has completed onboarding', example: true })
-  @IsOptional()
-  @IsBoolean()
-  onboardingCompleted?: boolean;
 }

--- a/src/modules/recurring-transactions/recurring-transactions.controller.ts
+++ b/src/modules/recurring-transactions/recurring-transactions.controller.ts
@@ -46,8 +46,8 @@ export class RecurringTransactionsController {
   ) {
     const result = await this.recurringTransactionsService.findAll({
       userId: req.user.id,
-      page: query.page ?? 1,
-      pageSize: query.pageSize ?? 20,
+      page: query.page,
+      pageSize: query.pageSize,
       status: query.status,
       type: query.type,
       categoryId: query.categoryId,

--- a/src/modules/recurring-transactions/recurring-transactions.service.ts
+++ b/src/modules/recurring-transactions/recurring-transactions.service.ts
@@ -1,13 +1,11 @@
 import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 
-import type { DrizzleDb } from '@/database/types.js';
 import { buildCacheKey, buildCachePrefix } from '@/modules/cache/cache-key.utils.js';
 import { CacheService } from '@/modules/cache/cache.service.js';
-import { TransactionCategoryRepository } from '@/modules/transaction-categories/transaction-categories.repository.js';
+import { TransactionCategoriesService } from '@/modules/transaction-categories/transaction-categories.service.js';
 import { ErrorCode } from '@/shared/enums/error-code.enum.js';
 import type { RecurringFrequency } from '@/shared/enums/recurring-frequency.enum.js';
-import type { TransactionType } from '@/shared/enums/transaction-type.enum.js';
 import {
   TRANSACTION_EVENTS,
   TransactionMutationEvent,
@@ -30,7 +28,7 @@ export class RecurringTransactionsService {
   // eslint-disable-next-line @typescript-eslint/max-params
   constructor(
     private readonly repository: RecurringTransactionsRepository,
-    private readonly categoryRepository: TransactionCategoryRepository,
+    private readonly categoriesService: TransactionCategoriesService,
     private readonly cacheService: CacheService,
     private readonly eventEmitter: EventEmitter2,
   ) {}
@@ -76,7 +74,7 @@ export class RecurringTransactionsService {
     }
 
     const result = await this.repository.transaction(async (tx) => {
-      await this.validateCategory({
+      await this.categoriesService.validateCategoryForTransaction({
         categoryId: data.categoryId,
         userId: data.userId,
         transactionType: data.type,
@@ -129,7 +127,12 @@ export class RecurringTransactionsService {
       if (data.categoryId !== undefined || data.type !== undefined) {
         const categoryId = data.categoryId ?? existing.categoryId;
         const type = data.type ?? existing.type;
-        await this.validateCategory({ categoryId, userId, transactionType: type, tx });
+        await this.categoriesService.validateCategoryForTransaction({
+          categoryId,
+          userId,
+          transactionType: type,
+          tx,
+        });
       }
 
       const effectiveStartDate = data.startDate ?? existing.startDate;
@@ -467,30 +470,6 @@ export class RecurringTransactionsService {
     }
 
     return next;
-  }
-
-  private async validateCategory(params: {
-    categoryId: string;
-    userId: string;
-    transactionType: TransactionType;
-    tx?: DrizzleDb;
-  }): Promise<void> {
-    const { categoryId, userId, transactionType, tx } = params;
-    const category = await this.categoryRepository.findForValidation(categoryId, userId, tx);
-
-    if (!category) {
-      throw new NotFoundException({
-        code: ErrorCode.RESOURCE_NOT_FOUND,
-        message: `Category ${categoryId} not found`,
-      });
-    }
-
-    if (category.type !== transactionType) {
-      throw new BadRequestException({
-        code: ErrorCode.BAD_REQUEST,
-        message: `Category type "${category.type}" does not match transaction type "${transactionType}"`,
-      });
-    }
   }
 
   private async invalidateCache(userId: string): Promise<void> {

--- a/src/modules/transaction-categories/transaction-categories.controller.ts
+++ b/src/modules/transaction-categories/transaction-categories.controller.ts
@@ -41,8 +41,8 @@ export class TransactionCategoriesController {
   async findAll(@Query() query: CategoryQueryDto, @Request() req: AuthenticatedRequest) {
     const result = await this.categoriesService.findAll({
       userId: req.user.id,
-      page: query.page ?? 1,
-      pageSize: query.pageSize ?? 20,
+      page: query.page,
+      pageSize: query.pageSize,
       type: query.type,
       parentCategoryId: query.parentCategoryId,
       root: query.root,

--- a/src/modules/transaction-categories/transaction-categories.repository.ts
+++ b/src/modules/transaction-categories/transaction-categories.repository.ts
@@ -128,11 +128,12 @@ export class TransactionCategoryRepository {
       )
       .limit(1);
 
-    if (result.length === 0) {
+    const [row] = result;
+    if (!row) {
       return null;
     }
 
-    return this.toCategoryInfo(result[0] as typeof transactionCategories.$inferSelect);
+    return this.toCategoryInfo(row);
   }
 
   async existsByNameTypeAndParent(
@@ -174,7 +175,7 @@ export class TransactionCategoryRepository {
 
   async create(data: CreateCategoryData, tx?: DrizzleDb): Promise<CategoryInfo> {
     const db = tx ?? this.db;
-    const [category] = await db
+    const result = await db
       .insert(transactionCategories)
       .values({
         userId: data.userId,
@@ -184,7 +185,12 @@ export class TransactionCategoryRepository {
       })
       .returning();
 
-    return this.toCategoryInfo(category as typeof transactionCategories.$inferSelect);
+    const [row] = result;
+    if (!row) {
+      throw new Error('Insert did not return a row');
+    }
+
+    return this.toCategoryInfo(row);
   }
 
   async update(params: {
@@ -217,11 +223,12 @@ export class TransactionCategoryRepository {
       )
       .returning();
 
-    if (result.length === 0) {
+    const [row] = result;
+    if (!row) {
       return null;
     }
 
-    return this.toCategoryInfo(result[0] as typeof transactionCategories.$inferSelect);
+    return this.toCategoryInfo(row);
   }
 
   async softDelete(id: string, userId: string, tx?: DrizzleDb): Promise<boolean> {
@@ -319,7 +326,7 @@ export class TransactionCategoryRepository {
       )
       .limit(1);
 
-    return (result[0] as CategoryValidationInfo) ?? null;
+    return result[0] ?? null;
   }
 
   async findAllActiveByUserId(userId: string): Promise<CategoryInfo[]> {

--- a/src/modules/transaction-categories/transaction-categories.service.ts
+++ b/src/modules/transaction-categories/transaction-categories.service.ts
@@ -231,6 +231,30 @@ export class TransactionCategoriesService {
     await this.cacheService.delByPrefix(buildCachePrefix(CACHE_MODULE, userId));
   }
 
+  async validateCategoryForTransaction(params: {
+    categoryId: string;
+    userId: string;
+    transactionType?: TransactionType;
+    tx?: DrizzleDb;
+  }): Promise<void> {
+    const { categoryId, userId, transactionType, tx } = params;
+    const category = await this.categoryRepository.findForValidation(categoryId, userId, tx);
+
+    if (!category) {
+      throw new NotFoundException({
+        code: ErrorCode.RESOURCE_NOT_FOUND,
+        message: `Category ${categoryId} not found`,
+      });
+    }
+
+    if (transactionType && category.type !== transactionType) {
+      throw new BadRequestException({
+        code: ErrorCode.BAD_REQUEST,
+        message: `Category type "${category.type}" does not match transaction type "${transactionType}"`,
+      });
+    }
+  }
+
   private async checkDuplicateCategory(
     params: {
       userId: string;

--- a/src/modules/transactions-analytics/transactions-analytics.repository.ts
+++ b/src/modules/transactions-analytics/transactions-analytics.repository.ts
@@ -77,7 +77,15 @@ export class TransactionsAnalyticsRepository {
       .from(transactions)
       .where(and(...conditions));
 
-    const row = result[0] as NonNullable<(typeof result)[0]>;
+    const [row] = result;
+    if (!row) {
+      return {
+        totalIncome: '0.00',
+        totalExpenses: '0.00',
+        netBalance: '0.00',
+        transactionCount: 0,
+      };
+    }
 
     return {
       totalIncome: this.formatAmount(row.totalIncome),

--- a/src/modules/transactions/transactions.controller.ts
+++ b/src/modules/transactions/transactions.controller.ts
@@ -64,8 +64,8 @@ export class TransactionsController {
   async findAll(@Query() query: TransactionQueryDto, @Request() req: AuthenticatedRequest) {
     const result = await this.transactionsService.findAll({
       userId: req.user.id,
-      page: query.page ?? 1,
-      pageSize: query.pageSize ?? 20,
+      page: query.page,
+      pageSize: query.pageSize,
       search: query.search,
       type: query.type,
       categoryId: query.categoryId,

--- a/src/modules/transactions/transactions.service.ts
+++ b/src/modules/transactions/transactions.service.ts
@@ -4,11 +4,10 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { stringify as stringifyCsvStream } from 'csv-stringify';
 import { Decimal } from 'decimal.js';
 
-import type { DrizzleDb } from '@/database/types.js';
 import type { TransactionType } from '@/shared/enums/transaction-type.enum.js';
 import { buildCacheKey, buildCachePrefix } from '@/modules/cache/cache-key.utils.js';
 import { CacheService } from '@/modules/cache/cache.service.js';
-import { TransactionCategoryRepository } from '@/modules/transaction-categories/transaction-categories.repository.js';
+import { TransactionCategoriesService } from '@/modules/transaction-categories/transaction-categories.service.js';
 import { ErrorCode } from '@/shared/enums/error-code.enum.js';
 
 import {
@@ -33,7 +32,7 @@ export class TransactionsService {
   // eslint-disable-next-line @typescript-eslint/max-params
   constructor(
     private readonly transactionRepository: TransactionRepository,
-    private readonly categoryRepository: TransactionCategoryRepository,
+    private readonly categoriesService: TransactionCategoriesService,
     private readonly cacheService: CacheService,
     private readonly eventEmitter: EventEmitter2,
   ) {}
@@ -72,7 +71,7 @@ export class TransactionsService {
 
   async create(data: CreateTransactionData): Promise<TransactionInfo> {
     const result = await this.transactionRepository.transaction(async (tx) => {
-      await this.validateCategory({
+      await this.categoriesService.validateCategoryForTransaction({
         categoryId: data.categoryId,
         userId: data.userId,
         transactionType: data.type,
@@ -112,7 +111,12 @@ export class TransactionsService {
       if (data.categoryId !== undefined || data.type !== undefined) {
         const categoryId = data.categoryId ?? existing.categoryId;
         const type = data.type ?? existing.type;
-        await this.validateCategory({ categoryId, userId, transactionType: type, tx });
+        await this.categoriesService.validateCategoryForTransaction({
+          categoryId,
+          userId,
+          transactionType: type,
+          tx,
+        });
       }
 
       const updated = await this.transactionRepository.update({ id, userId, data, tx });
@@ -302,29 +306,5 @@ export class TransactionsService {
       Currency: row.currencyCode,
       ...(subcategoryName ? { Subcategory: subcategoryName } : {}),
     };
-  }
-
-  private async validateCategory(params: {
-    categoryId: string;
-    userId: string;
-    transactionType: TransactionType;
-    tx?: DrizzleDb;
-  }): Promise<void> {
-    const { categoryId, userId, transactionType, tx } = params;
-    const category = await this.categoryRepository.findForValidation(categoryId, userId, tx);
-
-    if (!category) {
-      throw new NotFoundException({
-        code: ErrorCode.RESOURCE_NOT_FOUND,
-        message: `Category ${categoryId} not found`,
-      });
-    }
-
-    if (category.type !== transactionType) {
-      throw new BadRequestException({
-        code: ErrorCode.BAD_REQUEST,
-        message: `Category type "${category.type}" does not match transaction type "${transactionType}"`,
-      });
-    }
   }
 }

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -45,8 +45,8 @@ export class UserController {
   @ApiResponse({ status: 200, type: UserListResponseDto })
   async findAll(@Query() query: UserQueryDto) {
     const result = await this.userService.findAll({
-      page: query.page ?? 1,
-      pageSize: query.pageSize ?? 20,
+      page: query.page,
+      pageSize: query.pageSize,
       search: query.search,
       role: query.role,
       sortBy: query.sortBy,

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -132,11 +132,12 @@ export class UserRepository {
       .where(and(eq(users.id, id), isNull(users.deletedAt)))
       .limit(1);
 
-    if (result.length === 0) {
+    const [row] = result;
+    if (!row) {
       return null;
     }
 
-    return this.toUserInfo(result[0] as User);
+    return this.toUserInfo(row);
   }
 
   async findByEmail(email: string): Promise<User | null> {
@@ -159,7 +160,7 @@ export class UserRepository {
   }
 
   async create(data: CreateUserData): Promise<UserInfo> {
-    const [user] = await this.db
+    const result = await this.db
       .insert(users)
       .values({
         email: data.email.toLowerCase(),
@@ -173,7 +174,12 @@ export class UserRepository {
       })
       .returning();
 
-    return this.toUserInfo(user as User);
+    const [row] = result;
+    if (!row) {
+      throw new Error('Insert did not return a row');
+    }
+
+    return this.toUserInfo(row);
   }
 
   async update(id: string, data: UpdateUserData): Promise<UserInfo | null> {
@@ -184,11 +190,12 @@ export class UserRepository {
 
     const result = await this.db.update(users).set(updates).where(eq(users.id, id)).returning();
 
-    if (result.length === 0) {
+    const [row] = result;
+    if (!row) {
       return null;
     }
 
-    return this.toUserInfo(result[0] as User);
+    return this.toUserInfo(row);
   }
 
   async hardDelete(id: string): Promise<boolean> {
@@ -214,14 +221,14 @@ export class UserRepository {
     };
   }
 
-  async findFullById(id: string): Promise<{
-    id: string;
-    email: string;
-    emailVerified: boolean;
-    passwordHash: string | null;
-    baseCurrencyCode: string | null;
-    onboardingCompleted: boolean;
-  }> {
+  async findFullById(
+    id: string,
+  ): Promise<
+    Pick<
+      User,
+      'id' | 'email' | 'emailVerified' | 'passwordHash' | 'baseCurrencyCode' | 'onboardingCompleted'
+    >
+  > {
     const result = await this.db
       .select({
         id: users.id,
@@ -250,11 +257,12 @@ export class UserRepository {
       .where(and(eq(users.id, id), isNull(users.deletedAt)))
       .limit(1);
 
-    if (result.length === 0) {
+    const [row] = result;
+    if (!row) {
       return null;
     }
 
-    return this.toProfileInfo(result[0] as User);
+    return this.toProfileInfo(row);
   }
 
   async findWithPasswordHash(
@@ -296,11 +304,12 @@ export class UserRepository {
 
     const result = await this.db.update(users).set(updates).where(eq(users.id, id)).returning();
 
-    if (result.length === 0) {
+    const [row] = result;
+    if (!row) {
       return null;
     }
 
-    return this.toProfileInfo(result[0] as User);
+    return this.toProfileInfo(row);
   }
 
   async updatePasswordHash(id: string, passwordHash: string): Promise<void> {

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -254,14 +254,7 @@ export class UserService {
     return this.userRepository.verifyEmail(token);
   }
 
-  async findFullById(userId: string): Promise<{
-    id: string;
-    email: string;
-    emailVerified: boolean;
-    passwordHash: string | null;
-    baseCurrencyCode: string | null;
-    onboardingCompleted: boolean;
-  }> {
+  async findFullById(userId: string) {
     return this.userRepository.findFullById(userId);
   }
 }

--- a/src/shared/dtos/pagination.dto.ts
+++ b/src/shared/dtos/pagination.dto.ts
@@ -5,18 +5,18 @@ import { IsOptional } from 'class-validator';
 import { IsIntField, MaxField, MinField } from '../decorators/validators.js';
 
 export class OffsetPaginationDto {
-  @ApiPropertyOptional({ example: 1 })
+  @ApiPropertyOptional({ example: 1, default: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsIntField()
   @MinField(1)
-  page?: number = 1;
+  page = 1;
 
-  @ApiPropertyOptional({ example: 20 })
+  @ApiPropertyOptional({ example: 20, default: 20 })
   @IsOptional()
   @Type(() => Number)
   @IsIntField()
   @MinField(1)
   @MaxField(100)
-  pageSize?: number = 20;
+  pageSize = 20;
 }

--- a/src/shared/utils/pagination.utils.ts
+++ b/src/shared/utils/pagination.utils.ts
@@ -1,6 +1,6 @@
 interface PaginationQuery {
-  page?: number;
-  pageSize?: number;
+  page: number;
+  pageSize: number;
 }
 
 interface PaginatedResult<T> {
@@ -22,8 +22,7 @@ export function buildPaginatedResponse<T>(
   query: PaginationQuery,
   result: PaginatedResult<T>,
 ): PaginatedResponse<T> {
-  const page = query.page ?? 1;
-  const pageSize = query.pageSize ?? 20;
+  const { page, pageSize } = query;
   const totalPages = Math.ceil(result.total / pageSize);
 
   return {


### PR DESCRIPTION
## Summary
- **#27 (P1):** Replace 13 unsafe `result[0] as T` casts with safe destructuring + null checks across 5 repository files
- **#28 (P2):** Extract duplicated `validateCategory` from 3 services into `TransactionCategoriesService.validateCategoryForTransaction()`
- **#34 (P2):** Move `loginStatusEnum` from `login-logs.ts` to `enums.ts`, change values to UPPER_CASE (`SUCCESS`/`FAILED`), with migration
- **#47 (P2):** Add `ParseUUIDPipe` to email verification token query param for input validation
- **#49 (P2):** Remove `onboardingCompleted` from `UpdateProfileDto` to prevent users bypassing the onboarding flow
- **#51 (P2):** Remove redundant `?? 1` / `?? 20` pagination defaults from 7 controllers — DTO defaults handle this; made DTO types non-optional
- **#52 (P2):** Register `TimeoutInterceptor` via DI with configurable `REQUEST_TIMEOUT_MS` env var instead of `new` instantiation

## Test plan
- [ ] `pnpm check-types` passes
- [ ] `pnpm lint:fix` passes with no changes
- [ ] `pnpm format` passes with no changes
- [ ] `pnpm db:migrate` applies migration `0015_flaky_butterfly.sql` successfully
- [ ] Verify existing `LoginLog` rows have status converted to UPPER_CASE after migration
- [ ] Verify login/social-login creates log entries with `SUCCESS`/`FAILED` status
- [ ] Verify `PATCH /api/profile` no longer accepts `onboardingCompleted` field
- [ ] Verify `GET /api/auth/verify-email?token=invalid` returns 400 (not redirect)
- [ ] Verify pagination works without explicit `page`/`pageSize` query params (defaults to page 1, size 20)
- [ ] Verify `REQUEST_TIMEOUT_MS` env var is respected (defaults to 30000ms)
- [ ] Verify category validation still works for transactions, recurring transactions, and budgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Email verification token validation now requires valid UUID format.

* **Configuration**
  * Request timeout is now configurable via `REQUEST_TIMEOUT_MS` environment variable (default: 30 seconds).

* **Bug Fixes**
  * Login status values standardized to uppercase for consistency.
  * Users can no longer manually set onboarding completion status via profile updates.

* **Database**
  * Applied schema migration to normalize login status enum values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->