### PR TITLE
fix: convert CountryCode/CurrencyCode PG enums to varchar(3) (#49)

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -7,7 +7,6 @@
 | #   | Priority | Finding                                                               | Effort | Impact | Agent(s)                                                | Status  |
 | --- | -------- | --------------------------------------------------------------------- | ------ | ------ | ------------------------------------------------------- | ------- |
 | 15  | P1       | No API versioning strategy                                            | Medium | High   | api-designer                                            | Todo    |
-| 17  | P1       | `CountryCode`/`CurrencyCode` as PG enums (250+150 values)             | High   | High   | database-optimizer, postgres-pro                        | Todo    |
 | 18b | P1       | Remaining two Redis connections (ioredis vs node-redis mismatch)      | High   | High   | performance-engineer                                    | Todo    |
 | 29  | P2       | `CachePort` abstraction exists but is dead code                       | Low    | Medium | architect-reviewer                                      | Todo    |
 | 31  | P2       | `delByPrefix` uses SCAN + sequential DEL (O(N) Redis)                 | Medium | Medium | architect-reviewer, performance-engineer                | Todo    |
@@ -50,18 +49,6 @@
 No URI versioning, no header versioning, no `enableVersioning()` call. Any breaking change will affect all clients with no migration path.
 
 **Fix:** Add `app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' })` in `src/main.ts`.
-
----
-
-#### 17. `CountryCode`/`CurrencyCode` as PG Enums (250+150 values)
-
-**Effort:** High | **Impact:** High | **Reported by:** database-optimizer, postgres-pro
-
-PostgreSQL `ALTER TYPE ... ADD VALUE` is non-transactional and cannot be rolled back. With 250 country codes and 150 currency codes, every ISO update requires a risky DDL migration.
-
-**Fix:** Convert to `varchar(3)` with application-layer validation. One-time significant migration.
-
-**File:** `src/database/schemas/enums.ts:9-442`
 
 ---
 
@@ -547,3 +534,4 @@ No documentation for required environment variables beyond the Zod schema. Incre
 | 22   | Missing partial indexes for `deletedAt IS NULL`            | 4      | M      | P1       | Done   |
 | 23   | `ilike` search on `description` with no trigram index      | 4      | M      | P1       | Done   |
 | 30   | ILIKE wildcards not escaped in `UserRepository.findAll`    | 3      | S      | P2       | Done   |
+| 17   | `CountryCode`/`CurrencyCode` PG enums to varchar(3)        | High   | H      | P1       | Done   |

--- a/drizzle/0017_light_catseye.sql
+++ b/drizzle/0017_light_catseye.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "Budget" ALTER COLUMN "currencyCode" SET DATA TYPE varchar(3);--> statement-breakpoint
+ALTER TABLE "RecurringTransaction" ALTER COLUMN "currencyCode" SET DATA TYPE varchar(3);--> statement-breakpoint
+ALTER TABLE "Transaction" ALTER COLUMN "currencyCode" SET DATA TYPE varchar(3);--> statement-breakpoint
+ALTER TABLE "User" ALTER COLUMN "countryCode" SET DATA TYPE varchar(3);--> statement-breakpoint
+ALTER TABLE "User" ALTER COLUMN "baseCurrencyCode" SET DATA TYPE varchar(3);--> statement-breakpoint
+DROP TYPE "public"."CountryCode";--> statement-breakpoint
+DROP TYPE "public"."CurrencyCode";

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1767 @@
+{
+  "id": "83d81903-5e7d-4ee0-8b40-817a9c9ec8cf",
+  "prevId": "b86c2ca5-5f6a-4322-a02c-4a3303408246",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.AuditLog": {
+      "name": "AuditLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AuditLog_actorId_idx": {
+          "name": "AuditLog_actorId_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_action_idx": {
+          "name": "AuditLog_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_createdAt_idx": {
+          "name": "AuditLog_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Budget": {
+      "name": "Budget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "BudgetPeriod",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "BudgetStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Budget_userId_idx": {
+          "name": "Budget_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_categoryId_idx": {
+          "name": "Budget_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_status_idx": {
+          "name": "Budget_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_startDate_endDate_idx": {
+          "name": "Budget_startDate_endDate_idx",
+          "columns": [
+            {
+              "expression": "startDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_status_endDate_idx": {
+          "name": "Budget_status_endDate_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status IN ('ACTIVE', 'EXCEEDED')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Budget_userId_User_id_fk": {
+          "name": "Budget_userId_User_id_fk",
+          "tableFrom": "Budget",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Budget_categoryId_TransactionCategory_id_fk": {
+          "name": "Budget_categoryId_TransactionCategory_id_fk",
+          "tableFrom": "Budget",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["categoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Budget_endDate_after_startDate": {
+          "name": "Budget_endDate_after_startDate",
+          "value": "\"endDate\" > \"startDate\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.DefaultTransactionCategory": {
+      "name": "DefaultTransactionCategory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentDefaultTransactionCategoryId": {
+          "name": "parentDefaultTransactionCategoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "DefaultTransactionCategory_name_type_parentDefaultTransactionCategoryId_key": {
+          "name": "DefaultTransactionCategory_name_type_parentDefaultTransactionCategoryId_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentDefaultTransactionCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DefaultTransactionCategory_type_idx": {
+          "name": "DefaultTransactionCategory_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DefaultTransactionCategory_parentDefaultTransactionCategoryId_idx": {
+          "name": "DefaultTransactionCategory_parentDefaultTransactionCategoryId_idx",
+          "columns": [
+            {
+              "expression": "parentDefaultTransactionCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DefaultTransactionCategory_parentDefaultTransactionCategoryId_DefaultTransactionCategory_id_fk": {
+          "name": "DefaultTransactionCategory_parentDefaultTransactionCategoryId_DefaultTransactionCategory_id_fk",
+          "tableFrom": "DefaultTransactionCategory",
+          "tableTo": "DefaultTransactionCategory",
+          "columnsFrom": ["parentDefaultTransactionCategoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KnownDevice": {
+      "name": "KnownDevice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstSeenAt": {
+          "name": "firstSeenAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "KnownDevice_userId_User_id_fk": {
+          "name": "KnownDevice_userId_User_id_fk",
+          "tableFrom": "KnownDevice",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "KnownDevice_userId_ipAddress_userAgent_unique": {
+          "name": "KnownDevice_userId_ipAddress_userAgent_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userId", "ipAddress", "userAgent"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LoginLog": {
+      "name": "LoginLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "LoginStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failReason": {
+          "name": "failReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LoginLog_userId_idx": {
+          "name": "LoginLog_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LoginLog_createdAt_idx": {
+          "name": "LoginLog_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LoginLog_userId_User_id_fk": {
+          "name": "LoginLog_userId_User_id_fk",
+          "tableFrom": "LoginLog",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecurringTransaction": {
+      "name": "RecurringTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "RecurringFrequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextOccurrenceDate": {
+          "name": "nextOccurrenceDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "RecurringTransactionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RecurringTransaction_userId_idx": {
+          "name": "RecurringTransaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_categoryId_idx": {
+          "name": "RecurringTransaction_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_status_idx": {
+          "name": "RecurringTransaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_nextOccurrenceDate_idx": {
+          "name": "RecurringTransaction_nextOccurrenceDate_idx",
+          "columns": [
+            {
+              "expression": "nextOccurrenceDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_type_idx": {
+          "name": "RecurringTransaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecurringTransaction_userId_User_id_fk": {
+          "name": "RecurringTransaction_userId_User_id_fk",
+          "tableFrom": "RecurringTransaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RecurringTransaction_userId_categoryId_TransactionCategory_userId_id_fk": {
+          "name": "RecurringTransaction_userId_categoryId_TransactionCategory_userId_id_fk",
+          "tableFrom": "RecurringTransaction",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["userId", "categoryId"],
+          "columnsTo": ["userId", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "RecurringTransaction_interval_gt_0_chk": {
+          "name": "RecurringTransaction_interval_gt_0_chk",
+          "value": "\"RecurringTransaction\".\"interval\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.RefreshToken": {
+      "name": "RefreshToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceInfo": {
+          "name": "deviceInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RefreshToken_userId_idx": {
+          "name": "RefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RefreshToken_expiresAt_idx": {
+          "name": "RefreshToken_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RefreshToken_userId_User_id_fk": {
+          "name": "RefreshToken_userId_User_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RefreshToken_replacedByTokenId_RefreshToken_id_fk": {
+          "name": "RefreshToken_replacedByTokenId_RefreshToken_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "RefreshToken",
+          "columnsFrom": ["replacedByTokenId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "RefreshToken_token_unique": {
+          "name": "RefreshToken_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        },
+        "RefreshToken_replacedByTokenId_unique": {
+          "name": "RefreshToken_replacedByTokenId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["replacedByTokenId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TransactionCategory": {
+      "name": "TransactionCategory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentCategoryId": {
+          "name": "parentCategoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TransactionCategory_userId_name_type_parentCategoryId_key": {
+          "name": "TransactionCategory_userId_name_type_parentCategoryId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_userId_idx": {
+          "name": "TransactionCategory_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_parentCategoryId_idx": {
+          "name": "TransactionCategory_parentCategoryId_idx",
+          "columns": [
+            {
+              "expression": "parentCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_type_idx": {
+          "name": "TransactionCategory_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_userId_not_deleted_idx": {
+          "name": "TransactionCategory_userId_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TransactionCategory_userId_User_id_fk": {
+          "name": "TransactionCategory_userId_User_id_fk",
+          "tableFrom": "TransactionCategory",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "TransactionCategory_parentCategoryId_TransactionCategory_id_fk": {
+          "name": "TransactionCategory_parentCategoryId_TransactionCategory_id_fk",
+          "tableFrom": "TransactionCategory",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["parentCategoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "TransactionCategory_userId_id_key": {
+          "name": "TransactionCategory_userId_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["userId", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Transaction": {
+      "name": "Transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurringTransactionId": {
+          "name": "recurringTransactionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Transaction_userId_idx": {
+          "name": "Transaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_categoryId_idx": {
+          "name": "Transaction_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_date_idx": {
+          "name": "Transaction_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_type_idx": {
+          "name": "Transaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_currencyCode_idx": {
+          "name": "Transaction_currencyCode_idx",
+          "columns": [
+            {
+              "expression": "currencyCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_recurringTransactionId_idx": {
+          "name": "Transaction_recurringTransactionId_idx",
+          "columns": [
+            {
+              "expression": "recurringTransactionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_userId_date_idx": {
+          "name": "Transaction_userId_date_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_userId_currencyCode_date_idx": {
+          "name": "Transaction_userId_currencyCode_date_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currencyCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_description_trgm_idx": {
+          "name": "Transaction_description_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"description\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Transaction_userId_User_id_fk": {
+          "name": "Transaction_userId_User_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Transaction_recurringTransactionId_RecurringTransaction_id_fk": {
+          "name": "Transaction_recurringTransactionId_RecurringTransaction_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "RecurringTransaction",
+          "columnsFrom": ["recurringTransactionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "Transaction_userId_categoryId_TransactionCategory_userId_id_fk": {
+          "name": "Transaction_userId_categoryId_TransactionCategory_userId_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["userId", "categoryId"],
+          "columnsTo": ["userId", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Transaction_amount_positive": {
+          "name": "Transaction_amount_positive",
+          "value": "amount > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authProvider": {
+          "name": "authProvider",
+          "type": "AuthProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'LOCAL'"
+        },
+        "authProviderId": {
+          "name": "authProviderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "emailVerificationToken": {
+          "name": "emailVerificationToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerificationTokenExpiresAt": {
+          "name": "emailVerificationTokenExpiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "countryCode": {
+          "name": "countryCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseCurrencyCode": {
+          "name": "baseCurrencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingCompleted": {
+          "name": "onboardingCompleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "User_authProvider_authProviderId_unique": {
+          "name": "User_authProvider_authProviderId_unique",
+          "columns": [
+            {
+              "expression": "authProvider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "authProviderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"User\".\"authProviderId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_emailVerificationToken_idx": {
+          "name": "User_emailVerificationToken_idx",
+          "columns": [
+            {
+              "expression": "emailVerificationToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"User\".\"emailVerificationToken\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_id_not_deleted_idx": {
+          "name": "User_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "User_email_unique": {
+          "name": "User_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Verification": {
+      "name": "Verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Verification_identifier_idx": {
+          "name": "Verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AuthProvider": {
+      "name": "AuthProvider",
+      "schema": "public",
+      "values": ["LOCAL", "GOOGLE", "GITHUB"]
+    },
+    "public.BudgetPeriod": {
+      "name": "BudgetPeriod",
+      "schema": "public",
+      "values": ["WEEKLY", "MONTHLY", "QUARTERLY", "YEARLY", "CUSTOM"]
+    },
+    "public.BudgetStatus": {
+      "name": "BudgetStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "EXCEEDED"]
+    },
+    "public.LoginStatus": {
+      "name": "LoginStatus",
+      "schema": "public",
+      "values": ["SUCCESS", "FAILED"]
+    },
+    "public.RecurringFrequency": {
+      "name": "RecurringFrequency",
+      "schema": "public",
+      "values": ["DAILY", "WEEKLY", "MONTHLY", "YEARLY"]
+    },
+    "public.RecurringTransactionStatus": {
+      "name": "RecurringTransactionStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "PAUSED", "CANCELLED"]
+    },
+    "public.TransactionType": {
+      "name": "TransactionType",
+      "schema": "public",
+      "values": ["EXPENSE", "INCOME"]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": ["USER", "ADMIN", "SUPER_ADMIN"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1775824001865,
       "tag": "0016_lazy_johnny_blaze",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1775836146292,
+      "tag": "0017_light_catseye",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schemas/budgets.ts
+++ b/src/database/schemas/budgets.ts
@@ -1,7 +1,17 @@
-import { check, index, numeric, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import {
+  check,
+  index,
+  numeric,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
 import { relations, sql } from 'drizzle-orm';
 
-import { budgetPeriodEnum, budgetStatusEnum, currencyCodeEnum } from './enums.js';
+import type { CurrencyCode } from './enums.js';
+import { budgetPeriodEnum, budgetStatusEnum } from './enums.js';
 import { users } from './users.js';
 import { transactionCategories } from './transaction-categories.js';
 
@@ -16,7 +26,7 @@ export const budgets = pgTable(
       onDelete: 'set null',
     }),
     amount: numeric('amount', { precision: 19, scale: 2 }).notNull(),
-    currencyCode: currencyCodeEnum('currencyCode').notNull(),
+    currencyCode: varchar('currencyCode', { length: 3 }).$type<CurrencyCode>().notNull(),
     period: budgetPeriodEnum('period').notNull(),
     startDate: timestamp('startDate', { precision: 3, mode: 'date', withTimezone: true }).notNull(),
     endDate: timestamp('endDate', { precision: 3, mode: 'date', withTimezone: true }).notNull(),

--- a/src/database/schemas/enums.ts
+++ b/src/database/schemas/enums.ts
@@ -6,7 +6,7 @@ export const authProviderEnum = pgEnum('AuthProvider', ['LOCAL', 'GOOGLE', 'GITH
 
 export const transactionTypeEnum = pgEnum('TransactionType', ['EXPENSE', 'INCOME']);
 
-export const countryCodeEnum = pgEnum('CountryCode', [
+export const COUNTRY_CODES = [
   'AD',
   'AE',
   'AF',
@@ -256,7 +256,9 @@ export const countryCodeEnum = pgEnum('CountryCode', [
   'ZA',
   'ZM',
   'ZW',
-]);
+] as const;
+
+export type CountryCode = (typeof COUNTRY_CODES)[number];
 
 export const recurringFrequencyEnum = pgEnum('RecurringFrequency', [
   'DAILY',
@@ -283,7 +285,7 @@ export const budgetStatusEnum = pgEnum('BudgetStatus', ['ACTIVE', 'EXCEEDED']);
 
 export const loginStatusEnum = pgEnum('LoginStatus', ['SUCCESS', 'FAILED']);
 
-export const currencyCodeEnum = pgEnum('CurrencyCode', [
+export const CURRENCY_CODES = [
   'AED',
   'AFN',
   'ALL',
@@ -441,4 +443,6 @@ export const currencyCodeEnum = pgEnum('CurrencyCode', [
   'ZAR',
   'ZMW',
   'ZWL',
-]);
+] as const;
+
+export type CurrencyCode = (typeof CURRENCY_CODES)[number];

--- a/src/database/schemas/recurring-transactions.ts
+++ b/src/database/schemas/recurring-transactions.ts
@@ -8,11 +8,12 @@ import {
   text,
   timestamp,
   uuid,
+  varchar,
 } from 'drizzle-orm/pg-core';
 import { relations, sql } from 'drizzle-orm';
 
+import type { CurrencyCode } from './enums.js';
 import {
-  currencyCodeEnum,
   recurringFrequencyEnum,
   recurringTransactionStatusEnum,
   transactionTypeEnum,
@@ -31,7 +32,7 @@ export const recurringTransactions = pgTable(
     categoryId: uuid('categoryId').notNull(),
     type: transactionTypeEnum('type').notNull(),
     amount: numeric('amount', { precision: 19, scale: 2 }).notNull(),
-    currencyCode: currencyCodeEnum('currencyCode').notNull(),
+    currencyCode: varchar('currencyCode', { length: 3 }).$type<CurrencyCode>().notNull(),
     description: text('description'),
     frequency: recurringFrequencyEnum('frequency').notNull(),
     interval: integer('interval').notNull().default(1),

--- a/src/database/schemas/transactions.ts
+++ b/src/database/schemas/transactions.ts
@@ -7,10 +7,12 @@ import {
   text,
   timestamp,
   uuid,
+  varchar,
 } from 'drizzle-orm/pg-core';
 import { relations, sql } from 'drizzle-orm';
 
-import { currencyCodeEnum, transactionTypeEnum } from './enums.js';
+import type { CurrencyCode } from './enums.js';
+import { transactionTypeEnum } from './enums.js';
 import { users } from './users.js';
 import { transactionCategories } from './transaction-categories.js';
 import { recurringTransactions } from './recurring-transactions.js';
@@ -25,7 +27,7 @@ export const transactions = pgTable(
     categoryId: uuid('categoryId').notNull(),
     type: transactionTypeEnum('type').notNull(),
     amount: numeric('amount', { precision: 19, scale: 2 }).notNull(),
-    currencyCode: currencyCodeEnum('currencyCode').notNull(),
+    currencyCode: varchar('currencyCode', { length: 3 }).$type<CurrencyCode>().notNull(),
     date: timestamp('date', { precision: 3, mode: 'date', withTimezone: true }).notNull(),
     description: text('description'),
     recurringTransactionId: uuid('recurringTransactionId').references(

--- a/src/database/schemas/users.ts
+++ b/src/database/schemas/users.ts
@@ -1,7 +1,17 @@
-import { boolean, index, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import {
+  boolean,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
 import { relations, sql } from 'drizzle-orm';
 
-import { authProviderEnum, countryCodeEnum, currencyCodeEnum, userRoleEnum } from './enums.js';
+import type { CountryCode, CurrencyCode } from './enums.js';
+import { authProviderEnum, userRoleEnum } from './enums.js';
 import { refreshTokens } from './refresh-tokens.js';
 import { transactionCategories } from './transaction-categories.js';
 import { transactions } from './transactions.js';
@@ -23,8 +33,8 @@ export const users = pgTable(
       mode: 'date',
       withTimezone: true,
     }),
-    countryCode: countryCodeEnum('countryCode'),
-    baseCurrencyCode: currencyCodeEnum('baseCurrencyCode'),
+    countryCode: varchar('countryCode', { length: 3 }).$type<CountryCode>(),
+    baseCurrencyCode: varchar('baseCurrencyCode', { length: 3 }).$type<CurrencyCode>(),
     ipAddress: text('ipAddress'),
     userAgent: text('userAgent'),
     onboardingCompleted: boolean('onboardingCompleted').notNull().default(false),

--- a/src/database/seeds/transaction.seed.ts
+++ b/src/database/seeds/transaction.seed.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
+import type { CurrencyCode } from '@/shared/enums/currency-code.enum.js';
+
 import { transactions } from '../schemas/index.js';
 import type { SeedDb } from './client.js';
 import type { TransactionData } from './types.js';
-
-type CurrencyCode = (typeof transactions.currencyCode.enumValues)[number];
 
 const BATCH_SIZE = 100;
 

--- a/src/shared/decorators/validators.ts
+++ b/src/shared/decorators/validators.ts
@@ -72,7 +72,7 @@ export function MatchesField(pattern: RegExp, options?: ValidationOptions) {
   );
 }
 
-export function IsInField(values: unknown[], options?: ValidationOptions) {
+export function IsInField(values: readonly unknown[], options?: ValidationOptions) {
   return applyDecorators(IsIn(values, { ...options, context: { code: ErrorCode.INVALID_FORMAT } }));
 }
 

--- a/src/shared/enums/country-code.enum.ts
+++ b/src/shared/enums/country-code.enum.ts
@@ -1,5 +1,1 @@
-import { countryCodeEnum } from '@/database/schemas/enums.js';
-
-export const COUNTRY_CODES = countryCodeEnum.enumValues;
-
-export type CountryCode = (typeof COUNTRY_CODES)[number];
+export { COUNTRY_CODES, type CountryCode } from '@/database/schemas/enums.js';

--- a/src/shared/enums/currency-code.enum.ts
+++ b/src/shared/enums/currency-code.enum.ts
@@ -1,5 +1,1 @@
-import { currencyCodeEnum } from '@/database/schemas/enums.js';
-
-export const CURRENCY_CODES = currencyCodeEnum.enumValues;
-
-export type CurrencyCode = (typeof CURRENCY_CODES)[number];
+export { CURRENCY_CODES, type CurrencyCode } from '@/database/schemas/enums.js';


### PR DESCRIPTION
## Summary
- Convert `CountryCode` (250 values) and `CurrencyCode` (150 values) from PostgreSQL enums to `varchar(3)` columns across all 4 schema files (users, transactions, budgets, recurring-transactions)
- Replace `pgEnum` declarations with `as const` arrays and derived TypeScript types, preserving full type safety via Drizzle's `$type<>()`
- Update `IsInField` validator to accept `readonly` arrays for compatibility with `as const`
- Existing `@IsInField(COUNTRY_CODES)` / `@IsInField(CURRENCY_CODES)` decorators on DTOs provide application-layer validation
- Generate migration `0017_light_catseye.sql` that safely converts columns and drops enum types

## Test plan
- [ ] Run `pnpm check-types` — passes with zero errors
- [ ] Run `pnpm lint:fix` — no lint issues
- [ ] Run `pnpm db:migrate` against a fresh or existing database — migration applies cleanly
- [ ] Verify existing data is preserved after migration (enum text values cast losslessly to varchar)
- [ ] Test creating/updating transactions, budgets, recurring transactions with valid currency codes
- [ ] Test creating/updating user profile with valid country/currency codes
- [ ] Test that invalid codes are rejected by DTO validation (e.g. `currencyCode: "INVALID"`)
- [ ] Verify Swagger UI still shows enum dropdowns for country/currency code fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated country and currency code storage in the database, transitioning from PostgreSQL enums to varchar columns for improved flexibility and enhanced type consistency throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->