### PR TITLE
fix: add composite indexes, updatedAt triggers, and schema constraints (#50)

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -11,14 +11,6 @@
 | 29  | P2       | `CachePort` abstraction exists but is dead code                       | Low    | Medium | architect-reviewer                                      | Todo    |
 | 31  | P2       | `delByPrefix` uses SCAN + sequential DEL (O(N) Redis)                 | Medium | Medium | architect-reviewer, performance-engineer                | Todo    |
 | 32  | P2       | Export loads 10K rows + JSON.stringify into memory                    | Medium | Medium | architect-reviewer, performance-engineer                | Todo    |
-| 35  | P2       | Analytics `::date` cast ignores user timezone                         | Medium | Medium | database-optimizer                                      | Todo    |
-| 36  | P2       | `sql.raw` used for granularity string in `getTrends`                  | Low    | Medium | database-optimizer                                      | Todo    |
-| 37  | P2       | Redundant plain index on `RefreshToken.token`                         | Low    | Medium | database-optimizer                                      | Todo    |
-| 38  | P2       | Missing composite index `(status, nextOccurrenceDate)` for scheduler  | Low    | Medium | postgres-pro                                            | Todo    |
-| 39  | P2       | Missing `(actorId, createdAt)` composite on AuditLog/LoginLog         | Low    | Medium | postgres-pro                                            | Todo    |
-| 40  | P2       | `updatedAt` only updated by ORM, not DB trigger                       | Medium | Medium | postgres-pro                                            | Todo    |
-| 41  | P2       | `RecurringTransaction` missing `endDate > startDate` check            | Low    | Medium | postgres-pro                                            | Todo    |
-| 42  | P2       | Duplicate FK on `Transaction.categoryId` (inline + composite)         | Low    | Medium | postgres-pro                                            | Todo    |
 | 43  | P2       | `enableImplicitConversion: true` in ValidationPipe                    | Medium | Medium | security-auditor, nestjs-expert                         | Todo    |
 | 44  | P2       | JWT algorithm not explicitly specified                                | Low    | Medium | security-auditor                                        | Todo    |
 | 45  | P2       | Token blacklist fail-open design (no monitoring)                      | Medium | Medium | security-auditor                                        | Todo    |
@@ -101,100 +93,6 @@ Called on every mutation. `SCAN` iterates all keys; `DEL` runs per batch. Gets s
 **Fix:** Use streaming JSON serializer; remove pretty-printing for file downloads.
 
 **Files:** `src/modules/transactions/transactions.repository.ts:96`, `src/modules/transactions/transactions.service.ts:267`
-
----
-
-#### 35. Analytics `::date` Cast Ignores User Timezone
-
-**Effort:** Medium | **Impact:** Medium | **Reported by:** database-optimizer
-
-`transactions.date::date` uses the server's timezone setting, not the user's. Daily totals are wrong for non-UTC users.
-
-**Fix:** Thread user timezone through queries: `(date AT TIME ZONE $tz)::date`.
-
-**File:** `src/modules/transactions-analytics/transactions-analytics.repository.ts:187,119`
-
----
-
-#### 36. `sql.raw` Used for Granularity String
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** database-optimizer
-
-Bypasses Drizzle's parameterization. Currently safe (validated enum) but fragile for future refactoring.
-
-**Fix:** Use a const map or bound parameter.
-
-**File:** `src/modules/transactions-analytics/transactions-analytics.repository.ts:119`
-
----
-
-#### 37. Redundant Plain Index on `RefreshToken.token`
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** database-optimizer
-
-The `.unique()` constraint already creates a btree index. Migration 0000 creates a second plain index -- pure write overhead.
-
-**Fix:** Drop the redundant index in a new migration.
-
-**File:** `src/database/schemas/refresh-tokens.ts:13`
-
----
-
-#### 38. Missing Composite Index for Scheduler Query
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** postgres-pro
-
-`findDueRecurringTransactions` filters `status = 'ACTIVE' AND nextOccurrenceDate <= today` with no composite index.
-
-**Fix:** Add `(status, nextOccurrenceDate)` partial index where `status = 'ACTIVE'`.
-
-**File:** `src/database/schemas/recurring-transactions.ts`
-
----
-
-#### 39. Missing `(actorId, createdAt)` Composite on AuditLog/LoginLog
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** postgres-pro
-
-Audit queries filter by `actorId` and sort by `createdAt` but have only separate single-column indexes.
-
-**Fix:** Add composite `(actorId, createdAt DESC)` index.
-
-**Files:** `src/database/schemas/audit-logs.ts`, `src/database/schemas/login-logs.ts`
-
----
-
-#### 40. `updatedAt` Only Updated by ORM, Not DB Trigger
-
-**Effort:** Medium | **Impact:** Medium | **Reported by:** postgres-pro
-
-`.$onUpdate(() => new Date())` fires only via Drizzle. Direct SQL, migrations, or bulk ops bypass it.
-
-**Fix:** Add `BEFORE UPDATE` triggers on `Transaction` and `Budget` tables.
-
-**Files:** All schema files with `updatedAt`
-
----
-
-#### 41. `RecurringTransaction` Missing `endDate > startDate` Check
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** postgres-pro
-
-`Budget` has this check but `RecurringTransaction` does not. An `endDate` before `startDate` silently results in a record that never fires.
-
-**File:** `src/database/schemas/recurring-transactions.ts`
-
----
-
-#### 42. Duplicate FK on `Transaction.categoryId`
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** postgres-pro
-
-Inline `.references()` generates one FK; composite FK at lines 54-58 generates another. Two FKs on the same column = double validation overhead.
-
-**Fix:** Remove the inline `.references()`.
-
-**File:** `src/database/schemas/transactions.ts:25`
 
 ---
 
@@ -471,67 +369,75 @@ No documentation for required environment variables beyond the Zod schema. Incre
 
 ## Completed Fixes (History)
 
-| #    | Finding                                                    | Impact | Effort | Priority | Status |
-| ---- | ---------------------------------------------------------- | ------ | ------ | -------- | ------ |
-| 1    | Add Helmet security headers                                | 5      | S      | P0       | Done   |
-| 2    | Remove default JWT_SECRET                                  | 5      | S      | P0       | Done   |
-| 3    | Fix CORS default to deny all                               | 5      | S      | P0       | Done   |
-| 4    | Enable graceful shutdown hooks                             | 5      | S      | P0       | Done   |
-| 5    | Filter soft-deleted users from login                       | 5      | S      | P0       | Done   |
-| 6    | Fix login timing side-channel                              | 4      | S      | P0       | Done   |
-| 7    | Fix N+1 budget overspend cron                              | 5      | M      | P1       | Done   |
-| 8    | Add composite database indexes                             | 5      | S      | P1       | Done   |
-| 9    | Push refresh token filters to SQL                          | 4      | S      | P1       | Done   |
-| 10   | Cap export with LIMIT + streaming                          | 5      | M      | P1       | Done   |
-| 11   | Replace isDescendantOf with CTE                            | 4      | S      | P1       | Done   |
-| 12   | Rate limiting fail-closed on Redis down                    | 5      | M      | P1       | Done   |
-| 13   | Per-endpoint throttling on expensive ops                   | 4      | S      | P1       | Done   |
-| 14   | Protect /process endpoint (admin-only)                     | 4      | S      | P1       | Done   |
-| 15   | Align admin password policy                                | 4      | S      | P1       | Done   |
-| 16   | Fix service-to-DB architecture violation                   | 4      | M      | P1       | Done   |
-| 17   | Add JWT session validation / blacklist                     | 5      | L      | P1       | Done   |
-| 18   | Consolidate 3 Redis connections (3→2)                      | 4      | M      | P1       | Done   |
-| 19   | Domain events for cache invalidation                       | 4      | L      | P2       | Done   |
-| 20   | Extract pagination helper                                  | 3      | S      | P2       | Done   |
-| 21   | Remove/complete TransformInterceptor                       | 3      | S      | P2       | Done   |
-| 23   | Async CSV parsing                                          | 4      | M      | P2       | Done   |
-| 24   | Cache stampede protection                                  | 4      | M      | P2       | Done   |
-| 25   | Migrate date columns to timestamptz                        | 4      | M      | P2       | Done   |
-| 26   | CSRF protection for cookie auth                            | 4      | M      | P2       | Done   |
-| 27   | Disable Swagger in production                              | 3      | S      | P2       | Done   |
-| 28   | Consistent validator decorators                            | 3      | S      | P2       | Done   |
-| 29   | Add database CHECK constraints                             | 3      | S      | P2       | Done   |
-| 30   | Fix NULLS NOT DISTINCT on unique index                     | 3      | S      | P2       | Done   |
-| 31   | Decimal arithmetic for money                               | 4      | M      | P2       | Done   |
-| 32   | HTTP response compression                                  | 2      | S      | P3       | Done   |
-| 33   | Add statement_timeout                                      | 3      | S      | P3       | Done   |
-| 34   | Sort params on all collections                             | 2      | M      | P3       | Done   |
-| A-2  | No PostgreSQL config in Docker Compose                     | 5      | S      | P0       | Done   |
-| A-4  | CSRF token missing from CORS allowedHeaders                | 4      | S      | P1       | Done   |
-| A-5  | Missing CsrfGuard on revoke-refresh-token                  | 4      | S      | P1       | Done   |
-| A-6  | CSRF token comparison not timing-safe                      | 4      | S      | P1       | Done   |
-| A-12 | Missing index on emailVerificationToken                    | 4      | S      | P1       | Done   |
-| A-16 | Throttler auth bypass returns true                         | 4      | S      | P1       | Done   |
-| A-19 | findByParentCategory has no LIMIT                          | 4      | S      | P1       | Done   |
-| A-20 | Docker PG port exposed on all interfaces                   | 4      | S      | P1       | Done   |
-| A-21 | Docker default password in plaintext                       | 4      | S      | P1       | Done   |
-| A-25 | AllExceptionsFilter uses @Optional()                       | 4      | S      | P1       | Done   |
-| A-60 | sameSite stored as string losing type                      | 3      | S      | P2       | Done   |
-| A-7  | AuthService layer violation (UserRepository)               | 4      | M      | P1       | Done   |
-| A-8  | ProfileService layer violation (UserRepository)            | 4      | M      | P1       | Done   |
-| A-33 | Excessive constructor params (AuthService)                 | 3      | M      | P2       | Done   |
-| 27   | Replace `result[0] as T` casts with destructuring          | High   | M      | P1       | Done   |
-| 28   | Extract duplicated category validation                     | Medium | M      | P2       | Done   |
-| 34   | Move `loginStatusEnum` to enums.ts + UPPER_CASE            | Medium | S      | P2       | Done   |
-| 47   | Add ParseUUIDPipe to email verification token              | Medium | S      | P2       | Done   |
-| 49   | Remove `onboardingCompleted` from UpdateProfileDto         | Medium | S      | P2       | Done   |
-| 51   | Remove redundant pagination defaults from controllers      | Medium | S      | P2       | Done   |
-| 52   | Register TimeoutInterceptor via DI                         | Medium | S      | P2       | Done   |
-| 9    | Soft-delete unique constraint blocks category recreation   | 5      | M      | P1       | Done   |
-| 11   | Timestamps missing `withTimezone` across most tables       | 5      | M      | P1       | Done   |
-| 13   | Double-query pattern on create/update                      | 4      | M      | P1       | Done   |
-| 14   | Sequential processing in `processAllRecurringTransactions` | 4      | M      | P1       | Done   |
-| 22   | Missing partial indexes for `deletedAt IS NULL`            | 4      | M      | P1       | Done   |
-| 23   | `ilike` search on `description` with no trigram index      | 4      | M      | P1       | Done   |
-| 30   | ILIKE wildcards not escaped in `UserRepository.findAll`    | 3      | S      | P2       | Done   |
-| 17   | `CountryCode`/`CurrencyCode` PG enums to varchar(3)        | High   | H      | P1       | Done   |
+| #    | Finding                                                       | Impact | Effort | Priority | Status |
+| ---- | ------------------------------------------------------------- | ------ | ------ | -------- | ------ |
+| 1    | Add Helmet security headers                                   | 5      | S      | P0       | Done   |
+| 2    | Remove default JWT_SECRET                                     | 5      | S      | P0       | Done   |
+| 3    | Fix CORS default to deny all                                  | 5      | S      | P0       | Done   |
+| 4    | Enable graceful shutdown hooks                                | 5      | S      | P0       | Done   |
+| 5    | Filter soft-deleted users from login                          | 5      | S      | P0       | Done   |
+| 6    | Fix login timing side-channel                                 | 4      | S      | P0       | Done   |
+| 7    | Fix N+1 budget overspend cron                                 | 5      | M      | P1       | Done   |
+| 8    | Add composite database indexes                                | 5      | S      | P1       | Done   |
+| 9    | Push refresh token filters to SQL                             | 4      | S      | P1       | Done   |
+| 10   | Cap export with LIMIT + streaming                             | 5      | M      | P1       | Done   |
+| 11   | Replace isDescendantOf with CTE                               | 4      | S      | P1       | Done   |
+| 12   | Rate limiting fail-closed on Redis down                       | 5      | M      | P1       | Done   |
+| 13   | Per-endpoint throttling on expensive ops                      | 4      | S      | P1       | Done   |
+| 14   | Protect /process endpoint (admin-only)                        | 4      | S      | P1       | Done   |
+| 15   | Align admin password policy                                   | 4      | S      | P1       | Done   |
+| 16   | Fix service-to-DB architecture violation                      | 4      | M      | P1       | Done   |
+| 17   | Add JWT session validation / blacklist                        | 5      | L      | P1       | Done   |
+| 18   | Consolidate 3 Redis connections (3→2)                         | 4      | M      | P1       | Done   |
+| 19   | Domain events for cache invalidation                          | 4      | L      | P2       | Done   |
+| 20   | Extract pagination helper                                     | 3      | S      | P2       | Done   |
+| 21   | Remove/complete TransformInterceptor                          | 3      | S      | P2       | Done   |
+| 23   | Async CSV parsing                                             | 4      | M      | P2       | Done   |
+| 24   | Cache stampede protection                                     | 4      | M      | P2       | Done   |
+| 25   | Migrate date columns to timestamptz                           | 4      | M      | P2       | Done   |
+| 26   | CSRF protection for cookie auth                               | 4      | M      | P2       | Done   |
+| 27   | Disable Swagger in production                                 | 3      | S      | P2       | Done   |
+| 28   | Consistent validator decorators                               | 3      | S      | P2       | Done   |
+| 29   | Add database CHECK constraints                                | 3      | S      | P2       | Done   |
+| 30   | Fix NULLS NOT DISTINCT on unique index                        | 3      | S      | P2       | Done   |
+| 31   | Decimal arithmetic for money                                  | 4      | M      | P2       | Done   |
+| 32   | HTTP response compression                                     | 2      | S      | P3       | Done   |
+| 33   | Add statement_timeout                                         | 3      | S      | P3       | Done   |
+| 34   | Sort params on all collections                                | 2      | M      | P3       | Done   |
+| A-2  | No PostgreSQL config in Docker Compose                        | 5      | S      | P0       | Done   |
+| A-4  | CSRF token missing from CORS allowedHeaders                   | 4      | S      | P1       | Done   |
+| A-5  | Missing CsrfGuard on revoke-refresh-token                     | 4      | S      | P1       | Done   |
+| A-6  | CSRF token comparison not timing-safe                         | 4      | S      | P1       | Done   |
+| A-12 | Missing index on emailVerificationToken                       | 4      | S      | P1       | Done   |
+| A-16 | Throttler auth bypass returns true                            | 4      | S      | P1       | Done   |
+| A-19 | findByParentCategory has no LIMIT                             | 4      | S      | P1       | Done   |
+| A-20 | Docker PG port exposed on all interfaces                      | 4      | S      | P1       | Done   |
+| A-21 | Docker default password in plaintext                          | 4      | S      | P1       | Done   |
+| A-25 | AllExceptionsFilter uses @Optional()                          | 4      | S      | P1       | Done   |
+| A-60 | sameSite stored as string losing type                         | 3      | S      | P2       | Done   |
+| A-7  | AuthService layer violation (UserRepository)                  | 4      | M      | P1       | Done   |
+| A-8  | ProfileService layer violation (UserRepository)               | 4      | M      | P1       | Done   |
+| A-33 | Excessive constructor params (AuthService)                    | 3      | M      | P2       | Done   |
+| 27   | Replace `result[0] as T` casts with destructuring             | High   | M      | P1       | Done   |
+| 28   | Extract duplicated category validation                        | Medium | M      | P2       | Done   |
+| 34   | Move `loginStatusEnum` to enums.ts + UPPER_CASE               | Medium | S      | P2       | Done   |
+| 47   | Add ParseUUIDPipe to email verification token                 | Medium | S      | P2       | Done   |
+| 49   | Remove `onboardingCompleted` from UpdateProfileDto            | Medium | S      | P2       | Done   |
+| 51   | Remove redundant pagination defaults from controllers         | Medium | S      | P2       | Done   |
+| 52   | Register TimeoutInterceptor via DI                            | Medium | S      | P2       | Done   |
+| 9    | Soft-delete unique constraint blocks category recreation      | 5      | M      | P1       | Done   |
+| 11   | Timestamps missing `withTimezone` across most tables          | 5      | M      | P1       | Done   |
+| 13   | Double-query pattern on create/update                         | 4      | M      | P1       | Done   |
+| 14   | Sequential processing in `processAllRecurringTransactions`    | 4      | M      | P1       | Done   |
+| 22   | Missing partial indexes for `deletedAt IS NULL`               | 4      | M      | P1       | Done   |
+| 23   | `ilike` search on `description` with no trigram index         | 4      | M      | P1       | Done   |
+| 30   | ILIKE wildcards not escaped in `UserRepository.findAll`       | 3      | S      | P2       | Done   |
+| 17   | `CountryCode`/`CurrencyCode` PG enums to varchar(3)           | High   | H      | P1       | Done   |
+| 35   | Analytics `::date` cast ignores user timezone                 | Medium | M      | P2       | N/A    |
+| 36   | `sql.raw` used for granularity string in `getTrends`          | Medium | S      | P2       | Done   |
+| 37   | Redundant plain index on `RefreshToken.token`                 | Medium | S      | P2       | Done   |
+| 38   | Missing composite index for scheduler query                   | Medium | S      | P2       | Done   |
+| 39   | Missing `(actorId, createdAt)` composite on AuditLog/LoginLog | Medium | S      | P2       | Done   |
+| 40   | `updatedAt` only updated by ORM, not DB trigger               | Medium | M      | P2       | Done   |
+| 41   | `RecurringTransaction` missing `endDate > startDate` check    | Medium | S      | P2       | Done   |
+| 42   | Duplicate FK on `Transaction.categoryId`                      | Medium | S      | P2       | Done   |

--- a/drizzle/0018_calm_exiles.sql
+++ b/drizzle/0018_calm_exiles.sql
@@ -1,0 +1,25 @@
+DROP INDEX "AuditLog_actorId_idx";--> statement-breakpoint
+DROP INDEX "AuditLog_createdAt_idx";--> statement-breakpoint
+DROP INDEX "LoginLog_userId_idx";--> statement-breakpoint
+DROP INDEX "LoginLog_createdAt_idx";--> statement-breakpoint
+DROP INDEX "RecurringTransaction_status_idx";--> statement-breakpoint
+DROP INDEX "RecurringTransaction_nextOccurrenceDate_idx";--> statement-breakpoint
+CREATE INDEX "AuditLog_actorId_createdAt_idx" ON "AuditLog" USING btree ("actorId","createdAt" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "LoginLog_userId_createdAt_idx" ON "LoginLog" USING btree ("userId","createdAt" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "RecurringTransaction_status_nextOccurrenceDate_idx" ON "RecurringTransaction" USING btree ("status","nextOccurrenceDate") WHERE status = 'ACTIVE';--> statement-breakpoint
+ALTER TABLE "RecurringTransaction" ADD CONSTRAINT "RecurringTransaction_endDate_after_startDate" CHECK ("endDate" IS NULL OR "endDate" > "startDate");--> statement-breakpoint
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW."updatedAt" = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+CREATE TRIGGER set_updated_at_trigger BEFORE UPDATE ON "User" FOR EACH ROW EXECUTE FUNCTION set_updated_at();--> statement-breakpoint
+CREATE TRIGGER set_updated_at_trigger BEFORE UPDATE ON "Transaction" FOR EACH ROW EXECUTE FUNCTION set_updated_at();--> statement-breakpoint
+CREATE TRIGGER set_updated_at_trigger BEFORE UPDATE ON "Budget" FOR EACH ROW EXECUTE FUNCTION set_updated_at();--> statement-breakpoint
+CREATE TRIGGER set_updated_at_trigger BEFORE UPDATE ON "RecurringTransaction" FOR EACH ROW EXECUTE FUNCTION set_updated_at();--> statement-breakpoint
+CREATE TRIGGER set_updated_at_trigger BEFORE UPDATE ON "RefreshToken" FOR EACH ROW EXECUTE FUNCTION set_updated_at();--> statement-breakpoint
+CREATE TRIGGER set_updated_at_trigger BEFORE UPDATE ON "Verification" FOR EACH ROW EXECUTE FUNCTION set_updated_at();--> statement-breakpoint
+CREATE TRIGGER set_updated_at_trigger BEFORE UPDATE ON "TransactionCategory" FOR EACH ROW EXECUTE FUNCTION set_updated_at();--> statement-breakpoint
+CREATE TRIGGER set_updated_at_trigger BEFORE UPDATE ON "DefaultTransactionCategory" FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/drizzle/0019_productive_prodigy.sql
+++ b/drizzle/0019_productive_prodigy.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "AuditLog_createdAt_idx" ON "AuditLog" USING btree ("createdAt" DESC NULLS LAST);

--- a/drizzle/meta/0018_snapshot.json
+++ b/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,1745 @@
+{
+  "id": "f3dfa055-7327-4c94-a109-38b983153da1",
+  "prevId": "83d81903-5e7d-4ee0-8b40-817a9c9ec8cf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.AuditLog": {
+      "name": "AuditLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AuditLog_actorId_createdAt_idx": {
+          "name": "AuditLog_actorId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_action_idx": {
+          "name": "AuditLog_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Budget": {
+      "name": "Budget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "BudgetPeriod",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "BudgetStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Budget_userId_idx": {
+          "name": "Budget_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_categoryId_idx": {
+          "name": "Budget_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_status_idx": {
+          "name": "Budget_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_startDate_endDate_idx": {
+          "name": "Budget_startDate_endDate_idx",
+          "columns": [
+            {
+              "expression": "startDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_status_endDate_idx": {
+          "name": "Budget_status_endDate_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status IN ('ACTIVE', 'EXCEEDED')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Budget_userId_User_id_fk": {
+          "name": "Budget_userId_User_id_fk",
+          "tableFrom": "Budget",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Budget_categoryId_TransactionCategory_id_fk": {
+          "name": "Budget_categoryId_TransactionCategory_id_fk",
+          "tableFrom": "Budget",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["categoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Budget_endDate_after_startDate": {
+          "name": "Budget_endDate_after_startDate",
+          "value": "\"endDate\" > \"startDate\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.DefaultTransactionCategory": {
+      "name": "DefaultTransactionCategory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentDefaultTransactionCategoryId": {
+          "name": "parentDefaultTransactionCategoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "DefaultTransactionCategory_name_type_parentDefaultTransactionCategoryId_key": {
+          "name": "DefaultTransactionCategory_name_type_parentDefaultTransactionCategoryId_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentDefaultTransactionCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DefaultTransactionCategory_type_idx": {
+          "name": "DefaultTransactionCategory_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DefaultTransactionCategory_parentDefaultTransactionCategoryId_idx": {
+          "name": "DefaultTransactionCategory_parentDefaultTransactionCategoryId_idx",
+          "columns": [
+            {
+              "expression": "parentDefaultTransactionCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DefaultTransactionCategory_parentDefaultTransactionCategoryId_DefaultTransactionCategory_id_fk": {
+          "name": "DefaultTransactionCategory_parentDefaultTransactionCategoryId_DefaultTransactionCategory_id_fk",
+          "tableFrom": "DefaultTransactionCategory",
+          "tableTo": "DefaultTransactionCategory",
+          "columnsFrom": ["parentDefaultTransactionCategoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KnownDevice": {
+      "name": "KnownDevice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstSeenAt": {
+          "name": "firstSeenAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "KnownDevice_userId_User_id_fk": {
+          "name": "KnownDevice_userId_User_id_fk",
+          "tableFrom": "KnownDevice",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "KnownDevice_userId_ipAddress_userAgent_unique": {
+          "name": "KnownDevice_userId_ipAddress_userAgent_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userId", "ipAddress", "userAgent"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LoginLog": {
+      "name": "LoginLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "LoginStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failReason": {
+          "name": "failReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LoginLog_userId_createdAt_idx": {
+          "name": "LoginLog_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LoginLog_userId_User_id_fk": {
+          "name": "LoginLog_userId_User_id_fk",
+          "tableFrom": "LoginLog",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecurringTransaction": {
+      "name": "RecurringTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "RecurringFrequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextOccurrenceDate": {
+          "name": "nextOccurrenceDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "RecurringTransactionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RecurringTransaction_userId_idx": {
+          "name": "RecurringTransaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_categoryId_idx": {
+          "name": "RecurringTransaction_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_status_nextOccurrenceDate_idx": {
+          "name": "RecurringTransaction_status_nextOccurrenceDate_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextOccurrenceDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_type_idx": {
+          "name": "RecurringTransaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecurringTransaction_userId_User_id_fk": {
+          "name": "RecurringTransaction_userId_User_id_fk",
+          "tableFrom": "RecurringTransaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RecurringTransaction_userId_categoryId_TransactionCategory_userId_id_fk": {
+          "name": "RecurringTransaction_userId_categoryId_TransactionCategory_userId_id_fk",
+          "tableFrom": "RecurringTransaction",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["userId", "categoryId"],
+          "columnsTo": ["userId", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "RecurringTransaction_interval_gt_0_chk": {
+          "name": "RecurringTransaction_interval_gt_0_chk",
+          "value": "\"RecurringTransaction\".\"interval\" > 0"
+        },
+        "RecurringTransaction_endDate_after_startDate": {
+          "name": "RecurringTransaction_endDate_after_startDate",
+          "value": "\"endDate\" IS NULL OR \"endDate\" > \"startDate\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.RefreshToken": {
+      "name": "RefreshToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceInfo": {
+          "name": "deviceInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RefreshToken_userId_idx": {
+          "name": "RefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RefreshToken_expiresAt_idx": {
+          "name": "RefreshToken_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RefreshToken_userId_User_id_fk": {
+          "name": "RefreshToken_userId_User_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RefreshToken_replacedByTokenId_RefreshToken_id_fk": {
+          "name": "RefreshToken_replacedByTokenId_RefreshToken_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "RefreshToken",
+          "columnsFrom": ["replacedByTokenId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "RefreshToken_token_unique": {
+          "name": "RefreshToken_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        },
+        "RefreshToken_replacedByTokenId_unique": {
+          "name": "RefreshToken_replacedByTokenId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["replacedByTokenId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TransactionCategory": {
+      "name": "TransactionCategory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentCategoryId": {
+          "name": "parentCategoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TransactionCategory_userId_name_type_parentCategoryId_key": {
+          "name": "TransactionCategory_userId_name_type_parentCategoryId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_userId_idx": {
+          "name": "TransactionCategory_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_parentCategoryId_idx": {
+          "name": "TransactionCategory_parentCategoryId_idx",
+          "columns": [
+            {
+              "expression": "parentCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_type_idx": {
+          "name": "TransactionCategory_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_userId_not_deleted_idx": {
+          "name": "TransactionCategory_userId_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TransactionCategory_userId_User_id_fk": {
+          "name": "TransactionCategory_userId_User_id_fk",
+          "tableFrom": "TransactionCategory",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "TransactionCategory_parentCategoryId_TransactionCategory_id_fk": {
+          "name": "TransactionCategory_parentCategoryId_TransactionCategory_id_fk",
+          "tableFrom": "TransactionCategory",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["parentCategoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "TransactionCategory_userId_id_key": {
+          "name": "TransactionCategory_userId_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["userId", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Transaction": {
+      "name": "Transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurringTransactionId": {
+          "name": "recurringTransactionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Transaction_userId_idx": {
+          "name": "Transaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_categoryId_idx": {
+          "name": "Transaction_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_date_idx": {
+          "name": "Transaction_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_type_idx": {
+          "name": "Transaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_currencyCode_idx": {
+          "name": "Transaction_currencyCode_idx",
+          "columns": [
+            {
+              "expression": "currencyCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_recurringTransactionId_idx": {
+          "name": "Transaction_recurringTransactionId_idx",
+          "columns": [
+            {
+              "expression": "recurringTransactionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_userId_date_idx": {
+          "name": "Transaction_userId_date_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_userId_currencyCode_date_idx": {
+          "name": "Transaction_userId_currencyCode_date_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currencyCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_description_trgm_idx": {
+          "name": "Transaction_description_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"description\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Transaction_userId_User_id_fk": {
+          "name": "Transaction_userId_User_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Transaction_recurringTransactionId_RecurringTransaction_id_fk": {
+          "name": "Transaction_recurringTransactionId_RecurringTransaction_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "RecurringTransaction",
+          "columnsFrom": ["recurringTransactionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "Transaction_userId_categoryId_TransactionCategory_userId_id_fk": {
+          "name": "Transaction_userId_categoryId_TransactionCategory_userId_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["userId", "categoryId"],
+          "columnsTo": ["userId", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Transaction_amount_positive": {
+          "name": "Transaction_amount_positive",
+          "value": "amount > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authProvider": {
+          "name": "authProvider",
+          "type": "AuthProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'LOCAL'"
+        },
+        "authProviderId": {
+          "name": "authProviderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "emailVerificationToken": {
+          "name": "emailVerificationToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerificationTokenExpiresAt": {
+          "name": "emailVerificationTokenExpiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "countryCode": {
+          "name": "countryCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseCurrencyCode": {
+          "name": "baseCurrencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingCompleted": {
+          "name": "onboardingCompleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "User_authProvider_authProviderId_unique": {
+          "name": "User_authProvider_authProviderId_unique",
+          "columns": [
+            {
+              "expression": "authProvider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "authProviderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"User\".\"authProviderId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_emailVerificationToken_idx": {
+          "name": "User_emailVerificationToken_idx",
+          "columns": [
+            {
+              "expression": "emailVerificationToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"User\".\"emailVerificationToken\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_id_not_deleted_idx": {
+          "name": "User_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "User_email_unique": {
+          "name": "User_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Verification": {
+      "name": "Verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Verification_identifier_idx": {
+          "name": "Verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AuthProvider": {
+      "name": "AuthProvider",
+      "schema": "public",
+      "values": ["LOCAL", "GOOGLE", "GITHUB"]
+    },
+    "public.BudgetPeriod": {
+      "name": "BudgetPeriod",
+      "schema": "public",
+      "values": ["WEEKLY", "MONTHLY", "QUARTERLY", "YEARLY", "CUSTOM"]
+    },
+    "public.BudgetStatus": {
+      "name": "BudgetStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "EXCEEDED"]
+    },
+    "public.LoginStatus": {
+      "name": "LoginStatus",
+      "schema": "public",
+      "values": ["SUCCESS", "FAILED"]
+    },
+    "public.RecurringFrequency": {
+      "name": "RecurringFrequency",
+      "schema": "public",
+      "values": ["DAILY", "WEEKLY", "MONTHLY", "YEARLY"]
+    },
+    "public.RecurringTransactionStatus": {
+      "name": "RecurringTransactionStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "PAUSED", "CANCELLED"]
+    },
+    "public.TransactionType": {
+      "name": "TransactionType",
+      "schema": "public",
+      "values": ["EXPENSE", "INCOME"]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": ["USER", "ADMIN", "SUPER_ADMIN"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1760 @@
+{
+  "id": "ea23ea61-2658-4efd-86a5-349f980a7cfe",
+  "prevId": "f3dfa055-7327-4c94-a109-38b983153da1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.AuditLog": {
+      "name": "AuditLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AuditLog_actorId_createdAt_idx": {
+          "name": "AuditLog_actorId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_createdAt_idx": {
+          "name": "AuditLog_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_action_idx": {
+          "name": "AuditLog_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Budget": {
+      "name": "Budget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "BudgetPeriod",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "BudgetStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Budget_userId_idx": {
+          "name": "Budget_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_categoryId_idx": {
+          "name": "Budget_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_status_idx": {
+          "name": "Budget_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_startDate_endDate_idx": {
+          "name": "Budget_startDate_endDate_idx",
+          "columns": [
+            {
+              "expression": "startDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_status_endDate_idx": {
+          "name": "Budget_status_endDate_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status IN ('ACTIVE', 'EXCEEDED')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Budget_userId_User_id_fk": {
+          "name": "Budget_userId_User_id_fk",
+          "tableFrom": "Budget",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Budget_categoryId_TransactionCategory_id_fk": {
+          "name": "Budget_categoryId_TransactionCategory_id_fk",
+          "tableFrom": "Budget",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["categoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Budget_endDate_after_startDate": {
+          "name": "Budget_endDate_after_startDate",
+          "value": "\"endDate\" > \"startDate\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.DefaultTransactionCategory": {
+      "name": "DefaultTransactionCategory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentDefaultTransactionCategoryId": {
+          "name": "parentDefaultTransactionCategoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "DefaultTransactionCategory_name_type_parentDefaultTransactionCategoryId_key": {
+          "name": "DefaultTransactionCategory_name_type_parentDefaultTransactionCategoryId_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentDefaultTransactionCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DefaultTransactionCategory_type_idx": {
+          "name": "DefaultTransactionCategory_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DefaultTransactionCategory_parentDefaultTransactionCategoryId_idx": {
+          "name": "DefaultTransactionCategory_parentDefaultTransactionCategoryId_idx",
+          "columns": [
+            {
+              "expression": "parentDefaultTransactionCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DefaultTransactionCategory_parentDefaultTransactionCategoryId_DefaultTransactionCategory_id_fk": {
+          "name": "DefaultTransactionCategory_parentDefaultTransactionCategoryId_DefaultTransactionCategory_id_fk",
+          "tableFrom": "DefaultTransactionCategory",
+          "tableTo": "DefaultTransactionCategory",
+          "columnsFrom": ["parentDefaultTransactionCategoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KnownDevice": {
+      "name": "KnownDevice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstSeenAt": {
+          "name": "firstSeenAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "KnownDevice_userId_User_id_fk": {
+          "name": "KnownDevice_userId_User_id_fk",
+          "tableFrom": "KnownDevice",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "KnownDevice_userId_ipAddress_userAgent_unique": {
+          "name": "KnownDevice_userId_ipAddress_userAgent_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userId", "ipAddress", "userAgent"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LoginLog": {
+      "name": "LoginLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "LoginStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failReason": {
+          "name": "failReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LoginLog_userId_createdAt_idx": {
+          "name": "LoginLog_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LoginLog_userId_User_id_fk": {
+          "name": "LoginLog_userId_User_id_fk",
+          "tableFrom": "LoginLog",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecurringTransaction": {
+      "name": "RecurringTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "RecurringFrequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextOccurrenceDate": {
+          "name": "nextOccurrenceDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "RecurringTransactionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RecurringTransaction_userId_idx": {
+          "name": "RecurringTransaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_categoryId_idx": {
+          "name": "RecurringTransaction_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_status_nextOccurrenceDate_idx": {
+          "name": "RecurringTransaction_status_nextOccurrenceDate_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextOccurrenceDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_type_idx": {
+          "name": "RecurringTransaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecurringTransaction_userId_User_id_fk": {
+          "name": "RecurringTransaction_userId_User_id_fk",
+          "tableFrom": "RecurringTransaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RecurringTransaction_userId_categoryId_TransactionCategory_userId_id_fk": {
+          "name": "RecurringTransaction_userId_categoryId_TransactionCategory_userId_id_fk",
+          "tableFrom": "RecurringTransaction",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["userId", "categoryId"],
+          "columnsTo": ["userId", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "RecurringTransaction_interval_gt_0_chk": {
+          "name": "RecurringTransaction_interval_gt_0_chk",
+          "value": "\"RecurringTransaction\".\"interval\" > 0"
+        },
+        "RecurringTransaction_endDate_after_startDate": {
+          "name": "RecurringTransaction_endDate_after_startDate",
+          "value": "\"endDate\" IS NULL OR \"endDate\" > \"startDate\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.RefreshToken": {
+      "name": "RefreshToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceInfo": {
+          "name": "deviceInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RefreshToken_userId_idx": {
+          "name": "RefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RefreshToken_expiresAt_idx": {
+          "name": "RefreshToken_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RefreshToken_userId_User_id_fk": {
+          "name": "RefreshToken_userId_User_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RefreshToken_replacedByTokenId_RefreshToken_id_fk": {
+          "name": "RefreshToken_replacedByTokenId_RefreshToken_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "RefreshToken",
+          "columnsFrom": ["replacedByTokenId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "RefreshToken_token_unique": {
+          "name": "RefreshToken_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        },
+        "RefreshToken_replacedByTokenId_unique": {
+          "name": "RefreshToken_replacedByTokenId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["replacedByTokenId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TransactionCategory": {
+      "name": "TransactionCategory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentCategoryId": {
+          "name": "parentCategoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TransactionCategory_userId_name_type_parentCategoryId_key": {
+          "name": "TransactionCategory_userId_name_type_parentCategoryId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_userId_idx": {
+          "name": "TransactionCategory_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_parentCategoryId_idx": {
+          "name": "TransactionCategory_parentCategoryId_idx",
+          "columns": [
+            {
+              "expression": "parentCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_type_idx": {
+          "name": "TransactionCategory_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_userId_not_deleted_idx": {
+          "name": "TransactionCategory_userId_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TransactionCategory_userId_User_id_fk": {
+          "name": "TransactionCategory_userId_User_id_fk",
+          "tableFrom": "TransactionCategory",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "TransactionCategory_parentCategoryId_TransactionCategory_id_fk": {
+          "name": "TransactionCategory_parentCategoryId_TransactionCategory_id_fk",
+          "tableFrom": "TransactionCategory",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["parentCategoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "TransactionCategory_userId_id_key": {
+          "name": "TransactionCategory_userId_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["userId", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Transaction": {
+      "name": "Transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurringTransactionId": {
+          "name": "recurringTransactionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Transaction_userId_idx": {
+          "name": "Transaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_categoryId_idx": {
+          "name": "Transaction_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_date_idx": {
+          "name": "Transaction_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_type_idx": {
+          "name": "Transaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_currencyCode_idx": {
+          "name": "Transaction_currencyCode_idx",
+          "columns": [
+            {
+              "expression": "currencyCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_recurringTransactionId_idx": {
+          "name": "Transaction_recurringTransactionId_idx",
+          "columns": [
+            {
+              "expression": "recurringTransactionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_userId_date_idx": {
+          "name": "Transaction_userId_date_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_userId_currencyCode_date_idx": {
+          "name": "Transaction_userId_currencyCode_date_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currencyCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_description_trgm_idx": {
+          "name": "Transaction_description_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"description\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Transaction_userId_User_id_fk": {
+          "name": "Transaction_userId_User_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Transaction_recurringTransactionId_RecurringTransaction_id_fk": {
+          "name": "Transaction_recurringTransactionId_RecurringTransaction_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "RecurringTransaction",
+          "columnsFrom": ["recurringTransactionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "Transaction_userId_categoryId_TransactionCategory_userId_id_fk": {
+          "name": "Transaction_userId_categoryId_TransactionCategory_userId_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["userId", "categoryId"],
+          "columnsTo": ["userId", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Transaction_amount_positive": {
+          "name": "Transaction_amount_positive",
+          "value": "amount > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authProvider": {
+          "name": "authProvider",
+          "type": "AuthProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'LOCAL'"
+        },
+        "authProviderId": {
+          "name": "authProviderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "emailVerificationToken": {
+          "name": "emailVerificationToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerificationTokenExpiresAt": {
+          "name": "emailVerificationTokenExpiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "countryCode": {
+          "name": "countryCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseCurrencyCode": {
+          "name": "baseCurrencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingCompleted": {
+          "name": "onboardingCompleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "User_authProvider_authProviderId_unique": {
+          "name": "User_authProvider_authProviderId_unique",
+          "columns": [
+            {
+              "expression": "authProvider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "authProviderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"User\".\"authProviderId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_emailVerificationToken_idx": {
+          "name": "User_emailVerificationToken_idx",
+          "columns": [
+            {
+              "expression": "emailVerificationToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"User\".\"emailVerificationToken\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_id_not_deleted_idx": {
+          "name": "User_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "User_email_unique": {
+          "name": "User_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Verification": {
+      "name": "Verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Verification_identifier_idx": {
+          "name": "Verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AuthProvider": {
+      "name": "AuthProvider",
+      "schema": "public",
+      "values": ["LOCAL", "GOOGLE", "GITHUB"]
+    },
+    "public.BudgetPeriod": {
+      "name": "BudgetPeriod",
+      "schema": "public",
+      "values": ["WEEKLY", "MONTHLY", "QUARTERLY", "YEARLY", "CUSTOM"]
+    },
+    "public.BudgetStatus": {
+      "name": "BudgetStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "EXCEEDED"]
+    },
+    "public.LoginStatus": {
+      "name": "LoginStatus",
+      "schema": "public",
+      "values": ["SUCCESS", "FAILED"]
+    },
+    "public.RecurringFrequency": {
+      "name": "RecurringFrequency",
+      "schema": "public",
+      "values": ["DAILY", "WEEKLY", "MONTHLY", "YEARLY"]
+    },
+    "public.RecurringTransactionStatus": {
+      "name": "RecurringTransactionStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "PAUSED", "CANCELLED"]
+    },
+    "public.TransactionType": {
+      "name": "TransactionType",
+      "schema": "public",
+      "values": ["EXPENSE", "INCOME"]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": ["USER", "ADMIN", "SUPER_ADMIN"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1775836146292,
       "tag": "0017_light_catseye",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1775913195691,
+      "tag": "0018_calm_exiles",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1775913195691,
       "tag": "0018_calm_exiles",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1775915231290,
+      "tag": "0019_productive_prodigy",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schemas/audit-logs.ts
+++ b/src/database/schemas/audit-logs.ts
@@ -18,8 +18,7 @@ export const auditLogs = pgTable(
       .defaultNow(),
   },
   (table) => [
-    index('AuditLog_actorId_idx').on(table.actorId),
+    index('AuditLog_actorId_createdAt_idx').on(table.actorId, table.createdAt.desc()),
     index('AuditLog_action_idx').on(table.action),
-    index('AuditLog_createdAt_idx').on(table.createdAt),
   ],
 );

--- a/src/database/schemas/audit-logs.ts
+++ b/src/database/schemas/audit-logs.ts
@@ -19,6 +19,7 @@ export const auditLogs = pgTable(
   },
   (table) => [
     index('AuditLog_actorId_createdAt_idx').on(table.actorId, table.createdAt.desc()),
+    index('AuditLog_createdAt_idx').on(table.createdAt.desc()),
     index('AuditLog_action_idx').on(table.action),
   ],
 );

--- a/src/database/schemas/login-logs.ts
+++ b/src/database/schemas/login-logs.ts
@@ -17,8 +17,5 @@ export const loginLogs = pgTable(
       .notNull()
       .defaultNow(),
   },
-  (table) => [
-    index('LoginLog_userId_idx').on(table.userId),
-    index('LoginLog_createdAt_idx').on(table.createdAt),
-  ],
+  (table) => [index('LoginLog_userId_createdAt_idx').on(table.userId, table.createdAt.desc())],
 );

--- a/src/database/schemas/recurring-transactions.ts
+++ b/src/database/schemas/recurring-transactions.ts
@@ -54,10 +54,15 @@ export const recurringTransactions = pgTable(
   },
   (table) => [
     check('RecurringTransaction_interval_gt_0_chk', sql`${table.interval} > 0`),
+    check(
+      'RecurringTransaction_endDate_after_startDate',
+      sql`"endDate" IS NULL OR "endDate" > "startDate"`,
+    ),
     index('RecurringTransaction_userId_idx').on(table.userId),
     index('RecurringTransaction_categoryId_idx').on(table.categoryId),
-    index('RecurringTransaction_status_idx').on(table.status),
-    index('RecurringTransaction_nextOccurrenceDate_idx').on(table.nextOccurrenceDate),
+    index('RecurringTransaction_status_nextOccurrenceDate_idx')
+      .on(table.status, table.nextOccurrenceDate)
+      .where(sql`status = 'ACTIVE'`),
     index('RecurringTransaction_type_idx').on(table.type),
     foreignKey({
       columns: [table.userId, table.categoryId],

--- a/src/modules/transactions-analytics/transactions-analytics.repository.ts
+++ b/src/modules/transactions-analytics/transactions-analytics.repository.ts
@@ -124,7 +124,7 @@ export class TransactionsAnalyticsRepository {
   async getTrends(query: AnalyticsBaseQuery, granularity: Granularity): Promise<TrendRow[]> {
     const conditions = this.buildBaseConditions(query);
     const truncUnit = granularity === 'weekly' ? 'week' : 'month';
-    const periodExpr = sql`date_trunc(${sql.raw(`'${truncUnit}'`)}, ${transactions.date})`;
+    const periodExpr = sql`date_trunc(${truncUnit}, ${transactions.date})`;
 
     const rows = await this.db
       .select({


### PR DESCRIPTION
## Summary
- Replace single-column indexes with composite `(actorId, createdAt DESC)` on AuditLog and `(userId, createdAt DESC)` on LoginLog for efficient audit queries
- Add partial composite index `(status, nextOccurrenceDate) WHERE status = 'ACTIVE'` on RecurringTransaction for scheduler optimization
- Add `endDate > startDate` check constraint on RecurringTransaction (matching Budget pattern, allows NULL endDate)
- Add `set_updated_at()` trigger function + BEFORE UPDATE triggers on all 8 mutable tables to ensure `updatedAt` is set even for direct SQL/bulk operations
- Replace `sql.raw` with bound parameter in analytics `getTrends` query for safer parameterization
- Findings #37 and #42 were already resolved (index dropped in migration 0009, inline FK already removed)
- Finding #35 marked N/A — client sends dates as UTC, so `::date` cast is correct

## Test plan
- [ ] Run `pnpm db:migrate` and verify migration `0018_calm_exiles.sql` applies cleanly
- [ ] Verify composite indexes exist: `\di+ AuditLog_actorId_createdAt_idx`, `LoginLog_userId_createdAt_idx`, `RecurringTransaction_status_nextOccurrenceDate_idx`
- [ ] Verify old single-column indexes are dropped
- [ ] Test `updatedAt` trigger: update a row via raw SQL and confirm `updatedAt` changes
- [ ] Test check constraint: attempt to insert a RecurringTransaction with `endDate < startDate` and confirm rejection
- [ ] Test analytics trends endpoint still returns correct period groupings
- [ ] Run `pnpm check-types && pnpm lint:fix && pnpm format` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction analytics trend period grouping for correct date calculations.

* **Performance Improvements**
  * Improved query performance via new composite and partial indexes and added descending indexing for date fields.
  * Enabled automatic update-timestamping across core tables for more consistent metadata.

* **Data Validation**
  * Added a constraint to ensure recurring transaction end dates (when present) are after start dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->