### PR TITLE
fix: p1 security findings and swagger dto types (TRACK-57)

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -2,14 +2,57 @@
 
 > **Impact:** Critical > High > Medium > Low — severity if the issue reaches production.
 > **Effort:** Low (< 1h) · Medium (1-4h) · High (4h+) — estimated implementation time.
+> Updated: 2026-04-12
+> Analyzed by: architect-reviewer, security-auditor, performance-engineer, typescript-pro, postgres-pro, nestjs-expert, api-designer, database-optimizer, dependency-manager, refactoring-specialist
 
 ---
 
 ## Active Findings
 
-| #   | Priority | Finding                    | Effort | Impact | Agent(s)     | Status |
-| --- | -------- | -------------------------- | ------ | ------ | ------------ | ------ |
-| 15  | P1       | No API versioning strategy | Medium | High   | api-designer | Todo   |
+| #   | Priority | Finding                                                        | Effort | Impact | Agent(s)               | Status |
+| --- | -------- | -------------------------------------------------------------- | ------ | ------ | ---------------------- | ------ |
+| 15  | P1       | No API versioning strategy                                     | Medium | High   | api-designer           | Todo   |
+| 68  | P2       | Cross-module repository writes bypass service layer            | Medium | Medium | architect, nestjs      | Todo   |
+| 69  | P2       | existsByEmail counts soft-deleted users                        | Low    | Medium | security-auditor       | Todo   |
+| 70  | P2       | Admin can hard-delete own account                              | Low    | Medium | security-auditor       | Todo   |
+| 71  | P2       | socialAuthRedirectUrl as string without runtime guard          | Low    | Medium | security, typescript   | Todo   |
+| 72  | P2       | Validation errors documented as 400 but pipe throws 422        | Low    | Medium | api-designer           | Todo   |
+| 73  | P2       | BudgetResponseDto.endDate non-nullable but column optional     | Low    | Medium | api-designer           | Todo   |
+| 74  | P2       | POST /recurring-transactions/process lacks rate limiting       | Low    | Medium | api-designer           | Todo   |
+| 75  | P2       | Missing CHECK positive amount on Budget + RecurringTransaction | Low    | Medium | postgres-pro           | Todo   |
+| 76  | P2       | Missing composite index (userId, status) on Budget             | Low    | Medium | postgres-pro           | Todo   |
+| 77  | P2       | Verification table no unique constraint on identifier          | Low    | Medium | postgres-pro           | Todo   |
+| 78  | P2       | SQL alias-based GROUP BY/ORDER BY fragile pattern              | Low    | Medium | perf, postgres, db-opt | Todo   |
+| 79  | P2       | getSpentAmount no partial index for EXPENSE filter             | Low    | Medium | database-optimizer     | Todo   |
+| 80  | P2       | findOverlapping budget no composite index                      | Low    | Medium | database-optimizer     | Todo   |
+| 81  | P2       | bulkUpdateStatuses TOCTOU — no row lock                        | Medium | Medium | database-optimizer     | Todo   |
+| 82  | P2       | Redundant getCategoryInfo query per recurring iteration        | Medium | Medium | performance-engineer   | Todo   |
+| 83  | P2       | Duplicated getCategoryInfo method across repositories          | Low    | Medium | refactoring-specialist | Todo   |
+| 84  | P2       | Repeated field-by-field update construction in repos           | Medium | Medium | refactoring-specialist | Todo   |
+| 85  | P2       | Unsafe as casts on .returning() suppress Drizzle inference     | Low    | Medium | typescript-pro         | Todo   |
+| 86  | P2       | Filters/interceptors dual-registration pattern                 | Low    | Medium | nestjs-expert          | Todo   |
+| 87  | P3       | Login log writes fire-and-forget no error handling             | Low    | Low    | security-auditor       | Todo   |
+| 88  | P3       | Password change allows same password                           | Low    | Low    | security-auditor       | Todo   |
+| 89  | P3       | DELETE endpoints return 200 instead of 204                     | Low    | Low    | api-designer           | Todo   |
+| 90  | P3       | Missing Swagger response types on auth/providers + onboarding  | Low    | Low    | api-designer           | Todo   |
+| 91  | P3       | Import errors unstructured string array                        | Medium | Low    | api-designer           | Todo   |
+| 92  | P3       | LoginLog.email + KnownDevice.userId missing indexes            | Low    | Low    | postgres, db-opt       | Todo   |
+| 93  | P3       | Verification table no cleanup + no expiresAt index             | Low    | Low    | database-optimizer     | Todo   |
+| 94  | P3       | getUserSummary three separate COUNT queries                    | Low    | Low    | perf, db-opt           | Todo   |
+| 95  | P3       | Export redundant queries (categories + two round-trips)        | Low    | Low    | performance-engineer   | Todo   |
+| 96  | P3       | Analytics cache keys unbounded growth                          | Low    | Low    | performance-engineer   | Todo   |
+| 97  | P3       | Transaction_userId_date_idx DESC vs ASC mismatch               | Low    | Low    | performance-engineer   | Todo   |
+| 98  | P3       | Multiple unsafe as casts across codebase                       | Low    | Low    | typescript-pro         | Todo   |
+| 99  | P3       | Cache module name strings duplicated across modules            | Low    | Low    | architect, nestjs      | Todo   |
+| 100 | P3       | Dead code: createTransaction method + noop conditional         | Low    | Low    | refactoring-specialist | Todo   |
+| 101 | P3       | Duplicated pause/resume + findDue + hasUpdates patterns        | Low    | Low    | refactoring-specialist | Todo   |
+| 102 | P3       | Identical transaction\<T\> wrapper in 5 repositories           | Medium | Low    | refactoring-specialist | Todo   |
+| 103 | P3       | ScheduledTasksService mixes unrelated responsibilities         | Medium | Low    | nestjs-expert          | Todo   |
+| 104 | P3       | AuthController config assembly in constructor                  | Low    | Low    | nestjs-expert          | Todo   |
+| 105 | P3       | AuditLogInterceptor records raw URL not structured             | Low    | Low    | nestjs-expert          | Todo   |
+| 106 | P3       | Dependency vulnerabilities: flatted + vite                     | Low    | Low    | dependency-manager     | Todo   |
+| 107 | P3       | Unused dependencies: vitest, @nestjs/testing, jiti             | Low    | Low    | dependency-manager     | Todo   |
+| 108 | P3       | AuditLogModule unnecessary @Global                             | Low    | Low    | architect-reviewer     | Todo   |
 
 ---
 
@@ -26,6 +69,657 @@ No URI versioning, no header versioning, no `enableVersioning()` call. Any break
 **Fix:** Add `app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' })` in `src/main.ts`.
 
 ---
+
+### P2 -- Medium
+
+#### 68. Cross-Module Repository Writes Bypass Service Layer
+
+**Effort:** Medium | **Impact:** Medium | **Reported by:** architect-reviewer, nestjs-expert
+
+Multiple modules directly write to foreign tables, bypassing the owning module's service layer:
+
+1. `DefaultTransactionCategoryRepository.cloneDefaultCategoriesToUser` inserts into `transactionCategories` table
+2. `TransactionRepository.createCategories` and `findCategoriesByUser` operate on `transactionCategories` table
+3. `RecurringTransactionsRepository.createTransactionsBatch` inserts into `transactions` table
+4. `OnboardingService` injects `TransactionCategoryRepository` and `DefaultTransactionCategoryRepository` directly
+
+This bypasses business rules, validation, and cache invalidation. `TransactionCategoriesModule` and `DefaultTransactionCategoriesModule` both export their repositories, enabling the violations.
+
+**Fix:** Remove repository exports from both category modules. Add service-level methods for all cross-module operations. Have consumers call services instead of repositories.
+
+**Files:**
+
+- `src/modules/default-transaction-categories/default-transaction-categories.repository.ts:287-348`
+- `src/modules/transactions/transactions.repository.ts:413-462`
+- `src/modules/recurring-transactions/recurring-transactions.repository.ts:394-428`
+- `src/modules/onboarding/onboarding.service.ts:8-11`
+- `src/modules/transaction-categories/transaction-categories.module.ts:10`
+- `src/modules/default-transaction-categories/default-transaction-categories.module.ts:10`
+
+---
+
+#### 69. existsByEmail Counts Soft-Deleted Users Blocking Re-Registration
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** security-auditor
+
+`existsByEmail` queries without filtering `isNull(users.deletedAt)`. When a user soft-deletes their account, their email becomes permanently locked. This is inconsistent with `findByEmail` which correctly filters soft-deleted records, and creates a DoS vector.
+
+**Fix:** Add `isNull(users.deletedAt)` to the `where` clause of `existsByEmail`.
+
+**Files:**
+
+- `src/modules/user/user.repository.ts:177-183`
+
+---
+
+#### 70. Admin Can Hard-Delete Own Account
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** security-auditor
+
+The admin `DELETE /users/:id` endpoint has no self-deletion guard. An admin can permanently delete their own account, potentially leaving the system with no administrators. Unlike `assignRole` which explicitly blocks self-modification, `delete` has no such check.
+
+**Fix:** Add a self-deletion guard in `UserService.delete()` that compares the target `id` against the actor's `id`, rejecting with a `ForbiddenException` if they match.
+
+**Files:**
+
+- `src/modules/user/user.controller.ts:119-128`
+- `src/modules/user/user.service.ts:160-169`
+
+---
+
+#### 71. socialAuthRedirectUrl `as string` Without Runtime Guard
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** security-auditor, typescript-pro
+
+`this.socialAuthRedirectUrl` is typed `string | undefined` but cast to `string` with `as string` in `handleSocialCallback`. If undefined at runtime, `new URL(redirectUrl)` throws an uncaught TypeError. The `verifyEmail` method correctly validates with an explicit null check.
+
+**Fix:** Replace `as string` with a runtime guard: `if (!this.socialAuthRedirectUrl) throw new InternalServerErrorException('Social auth redirect URL is not configured');`.
+
+**Files:**
+
+- `src/modules/auth/auth.controller.ts:355`
+
+---
+
+#### 72. Validation Errors Documented as 400 but Pipe Throws 422
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** api-designer
+
+The global `ValidationPipe` is configured with `errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY` (422), but every controller documents `@ApiResponse({ status: 400, description: 'Validation error' })`. Clients relying on the Swagger spec will not handle 422 correctly.
+
+**Fix:** Replace all `@ApiResponse({ status: 400, description: 'Validation error' })` with `@ApiResponse({ status: 422, description: 'Validation error' })`. Reserve 400 only for explicit `BadRequestException` throws.
+
+**Files:**
+
+- `src/app/config/validation.config.ts:12-14`
+- All controllers with `@ApiResponse({ status: 400 })`
+
+---
+
+#### 73. BudgetResponseDto.endDate Non-Nullable but Column Optional
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** api-designer
+
+`CreateBudgetDto.endDate` and `UpdateBudgetDto.endDate` are `@IsOptional()`, so a budget may lack an end date. Yet `BudgetResponseDto.endDate` is declared as non-nullable `Date`, misleading clients.
+
+**Fix:** Change to `endDate: Date | null` and add `{ type: Date, nullable: true }` to its `@ApiProperty` decorator.
+
+**Files:**
+
+- `src/modules/budgets/dtos/budget-response.dto.ts:44-45`
+
+---
+
+#### 74. POST /recurring-transactions/process Lacks Rate Limiting
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** api-designer
+
+The `process` endpoint triggers bulk recurring transaction processing and is admin-only, but has no `@Throttle` decorator. A compromised admin token could invoke it in a tight loop causing mass duplicate transactions.
+
+**Fix:** Add `@Throttle({ default: { limit: 5, ttl: 60000 } })` to the `process` method.
+
+**Files:**
+
+- `src/modules/recurring-transactions/recurring-transactions.controller.ts:175-184`
+
+---
+
+#### 75. Missing CHECK Positive Amount on Budget and RecurringTransaction
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** postgres-pro
+
+The `Transaction` table has `CHECK (amount > 0)` but `Budget` and `RecurringTransaction` tables have no equivalent constraint. Zero or negative amounts are insertable via SQL.
+
+**Fix:** Add `check('Budget_amount_positive', sql\`amount > 0\`)`and`check('RecurringTransaction_amount_positive', sql\`amount > 0\`)`to the respective table constraints. Run`pnpm db:generate && pnpm db:migrate`.
+
+**Files:**
+
+- `src/database/schemas/budgets.ts:28,43-52`
+- `src/database/schemas/recurring-transactions.ts:34,55-71`
+
+---
+
+#### 76. Missing Composite Index (userId, status) on Budget
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** postgres-pro
+
+User-scoped budget queries filter by `userId` + `status` but only have separate single-column indexes. The nightly cron and user-facing list queries fall back to bitmap-and on two indexes.
+
+**Fix:** Add `index('Budget_userId_status_idx').on(table.userId, table.status)` to the Budget schema.
+
+**Files:**
+
+- `src/database/schemas/budgets.ts:43-52`
+- `src/modules/budgets/budgets.repository.ts:306-319`
+
+---
+
+#### 77. Verification Table No Unique Constraint on Identifier
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** postgres-pro
+
+Multiple concurrent requests can insert duplicate verification rows for the same identifier. A lookup returns whichever row is first, making prior tokens stale without invalidation.
+
+**Fix:** Replace the plain `index` on `identifier` with `uniqueIndex('Verification_identifier_key').on(table.identifier)`.
+
+**Files:**
+
+- `src/database/schemas/verifications.ts:3-19`
+
+---
+
+#### 78. SQL Alias-Based GROUP BY/ORDER BY Fragile Pattern
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** performance-engineer, postgres-pro, database-optimizer
+
+`getDailyTotals` groups by alias `day`, and `getCategoryBreakdown`/`getTopCategories` order by alias `total`. Using aliases in GROUP BY/ORDER BY is PostgreSQL-specific, fragile if aliases change, and prevents the planner from reusing computed expressions efficiently.
+
+**Fix:** Replace alias references with the full expressions: `.groupBy(sql\`${transactions.date}::date\`)` and `.orderBy(desc(sql\`SUM(${transactions.amount})\`))`.
+
+**Files:**
+
+- `src/modules/transactions-analytics/transactions-analytics.repository.ts:113,177,195,201-202`
+
+---
+
+#### 79. getSpentAmount No Partial Index for EXPENSE Filter
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** database-optimizer
+
+`getSpentAmount` queries with `type = 'EXPENSE'` but the existing `Transaction_userId_currencyCode_date_idx` doesn't include `type`. PostgreSQL re-filters all rows after the index scan.
+
+**Fix:** Add a partial composite index `ON "Transaction" ("userId", "currencyCode", "date" DESC) WHERE type = 'EXPENSE'`.
+
+**Files:**
+
+- `src/database/schemas/transactions.ts:45-64`
+- `src/modules/budgets/budgets.repository.ts:275-303`
+
+---
+
+#### 80. findOverlapping Budget No Composite Index
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** database-optimizer
+
+`findOverlapping` filters `userId + currencyCode + startDate + endDate + categoryId` but no composite index covers this combination.
+
+**Fix:** Add `index('Budget_userId_currencyCode_startDate_endDate_idx').on(table.userId, table.currencyCode, table.startDate, table.endDate)`.
+
+**Files:**
+
+- `src/modules/budgets/budgets.repository.ts:232-273`
+- `src/database/schemas/budgets.ts:43-52`
+
+---
+
+#### 81. bulkUpdateStatuses TOCTOU — No Row Lock
+
+**Effort:** Medium | **Impact:** Medium | **Reported by:** database-optimizer
+
+`bulkUpdateStatuses` wraps the UPDATE in a transaction but does not acquire `FOR UPDATE` locks. Between the read in `getSpentAmountForAllActiveBudgets` and the write, concurrent requests could mutate budgets.
+
+**Fix:** Add `FOR UPDATE` to the `findActiveBudgetsWithFutureEndDate` query, or perform spend aggregation and status update in a single SQL CTE.
+
+**Files:**
+
+- `src/modules/budgets/budgets.repository.ts:368-392`
+
+---
+
+#### 82. Redundant getCategoryInfo Query per Recurring Transaction Iteration
+
+**Effort:** Medium | **Impact:** Medium | **Reported by:** performance-engineer
+
+Both `create` and `update` in `RecurringTransactionsRepository` call `getCategoryInfo` as a second query. When `processAllRecurringTransactions` processes N records, each triggers an additional SELECT, yielding 2N round-trips instead of N. The category data is already known from the `RecurringTransactionInfo`.
+
+**Fix:** Skip the `getCategoryInfo` lookup when the category is already available, or restructure to accept pre-fetched category data.
+
+**Files:**
+
+- `src/modules/recurring-transactions/recurring-transactions.repository.ts:287-289,346-348,430-449`
+
+---
+
+#### 83. Duplicated getCategoryInfo Method Across Repositories
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** refactoring-specialist
+
+The `getCategoryInfo` private method is copy-pasted identically between `TransactionRepository` and `RecurringTransactionsRepository`.
+
+**Fix:** Extract a shared utility function `fetchCategoryJoinColumns(categoryId, db)` into `src/shared/utils/`.
+
+**Files:**
+
+- `src/modules/transactions/transactions.repository.ts:487-506`
+- `src/modules/recurring-transactions/recurring-transactions.repository.ts:430-449`
+
+---
+
+#### 84. Repeated Field-by-Field Update Construction in Repositories
+
+**Effort:** Medium | **Impact:** Medium | **Reported by:** refactoring-specialist
+
+Every repository `update` method manually checks each field with `if (data.X !== undefined) { updates.X = data.X; }`. This pattern repeats across 5+ repositories with up to 11 fields each.
+
+**Fix:** Extract a shared `buildDefinedUpdates<T>(data: Partial<T>): Partial<T>` utility that filters out undefined values.
+
+**Files:**
+
+- `src/modules/transactions/transactions.repository.ts:290-314`
+- `src/modules/recurring-transactions/recurring-transactions.repository.ts:300-334`
+- `src/modules/budgets/budgets.repository.ts:182-198`
+- `src/modules/user/user.repository.ts:316-333`
+
+---
+
+#### 85. Unsafe `as` Casts on .returning() Suppress Drizzle Inference
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** typescript-pro
+
+Both `TransactionRepository.update()` and `RecurringTransactionsRepository.update()` cast `.returning()` results to `(typeof table.$inferSelect)[]`, discarding Drizzle's own structural inference and masking potential schema mismatches.
+
+**Fix:** Remove the casts. Type the `updates` variable properly and let Drizzle infer the `.returning()` result. Use `satisfies` if stricter narrowing is needed.
+
+**Files:**
+
+- `src/modules/transactions/transactions.repository.ts:316-320`
+- `src/modules/recurring-transactions/recurring-transactions.repository.ts:336-340`
+
+---
+
+#### 86. Filters/Interceptors Dual-Registration Pattern
+
+**Effort:** Low | **Impact:** Medium | **Reported by:** nestjs-expert
+
+`AllExceptionsFilter`, `ProblemDetailsFilter`, `PaginationLinkInterceptor`, `RequestContextInterceptor`, and `TimeoutInterceptor` are listed as bare class providers in `AppModule`, then retrieved via `app.get(...)` in `main.ts` for global registration. Only `AuditLogInterceptor` uses the correct `APP_INTERCEPTOR` token pattern.
+
+**Fix:** Register each via its respective token (`APP_FILTER`, `APP_INTERCEPTOR`) using `{ provide: APP_FILTER, useClass: ... }` and remove the manual `app.get(...)` calls from `main.ts`.
+
+**Files:**
+
+- `src/app.module.ts:89-103`
+- `src/main.ts:44-50`
+
+---
+
+### P3 -- Low
+
+#### 87. Login Log Writes Fire-and-Forget No Error Handling
+
+**Effort:** Low | **Impact:** Low | **Reported by:** security-auditor
+
+All `loginLogRepo.create()` calls use `void` without `.catch()`. If the insert throws, an unhandled promise rejection crashes the process.
+
+**Fix:** Add `.catch()` to each `void this.loginLogRepo.create(...)` call to log the error without propagating it.
+
+**Files:**
+
+- `src/modules/auth/auth.service.ts:90,104,120,134,155,175,210`
+
+---
+
+#### 88. Password Change Allows Same Password
+
+**Effort:** Low | **Impact:** Low | **Reported by:** security-auditor
+
+`changePassword` validates the current password but does not check whether `newPassword` equals `currentPassword`. A user can "change" to the same value, burning through session invalidation without improving security.
+
+**Fix:** Add a comparison rejecting with `BadRequestException` if `dto.newPassword === dto.currentPassword`.
+
+**Files:**
+
+- `src/modules/profile/profile.service.ts:47-83`
+
+---
+
+#### 89. DELETE Endpoints Return 200 Instead of 204
+
+**Effort:** Low | **Impact:** Low | **Reported by:** api-designer
+
+All single-resource DELETE endpoints respond with 200 and a `{ message: "..." }` body. REST semantics specify 204 No Content for successful deletions.
+
+**Fix:** Change `@HttpCode(HttpStatus.OK)` to `@HttpCode(HttpStatus.NO_CONTENT)`, remove the return body, and update Swagger annotations. Keep 200 on bulk delete endpoints.
+
+**Files:**
+
+- `src/modules/transactions/transactions.controller.ts:224-235`
+- `src/modules/budgets/budgets.controller.ts:141-152`
+- `src/modules/transaction-categories/transaction-categories.controller.ts:119-131`
+- `src/modules/recurring-transactions/recurring-transactions.controller.ts:138-149`
+- `src/modules/user/user.controller.ts:120-128`
+
+---
+
+#### 90. Missing Swagger Response Types on auth/providers and onboarding
+
+**Effort:** Low | **Impact:** Low | **Reported by:** api-designer
+
+`GET /auth/providers` and `POST /onboarding/assign-default-categories` have `@ApiResponse` with no `type:` property. Clients cannot generate typed SDKs.
+
+**Fix:** Create `ProvidersResponseDto` and add `type: MessageResponseDto` / `type: ProvidersResponseDto` to the respective `@ApiResponse` decorators.
+
+**Files:**
+
+- `src/modules/auth/auth.controller.ts:261-270`
+- `src/modules/onboarding/onboarding.controller.ts:43-44`
+
+---
+
+#### 91. Import Errors Unstructured String Array
+
+**Effort:** Medium | **Impact:** Low | **Reported by:** api-designer
+
+Import row errors are returned as `errors: string[]` (e.g., `"Row 5: Invalid date format"`) rather than structured objects. Clients cannot programmatically identify which row failed.
+
+**Fix:** Define `ImportErrorDto { row: number; code: string; message: string }` and change `errors: string[]` to `errors: ImportErrorDto[]`.
+
+**Files:**
+
+- `src/modules/transactions/dtos/import-transaction-response.dto.ts:15-22`
+- `src/modules/transactions/transaction-import.service.ts:78-82`
+
+---
+
+#### 92. LoginLog.email and KnownDevice.userId Missing Indexes
+
+**Effort:** Low | **Impact:** Low | **Reported by:** postgres-pro, database-optimizer
+
+`LoginLog` has no index on `email` for brute-force detection queries. `KnownDevice` has no dedicated `userId` index — the wide unique composite index is suboptimal for user-scoped lookups.
+
+**Fix:** Add `index('LoginLog_email_createdAt_idx').on(table.email, table.createdAt.desc())` and `index('KnownDevice_userId_idx').on(table.userId)`.
+
+**Files:**
+
+- `src/database/schemas/login-logs.ts:11-20`
+- `src/database/schemas/known-devices.ts:22-28`
+
+---
+
+#### 93. Verification Table No Cleanup and No expiresAt Index
+
+**Effort:** Low | **Impact:** Low | **Reported by:** database-optimizer
+
+Expired verification records are never cleaned up. The table grows unbounded and any future TTL cleanup requires a sequential scan.
+
+**Fix:** Add `index('Verification_expiresAt_idx').on(table.expiresAt)` and add a scheduled cleanup task alongside `cleanExpiredSessions`.
+
+**Files:**
+
+- `src/database/schemas/verifications.ts:1-19`
+
+---
+
+#### 94. getUserSummary Three Separate COUNT Queries
+
+**Effort:** Low | **Impact:** Low | **Reported by:** performance-engineer, database-optimizer
+
+`getSummary` executes three independent `SELECT count(*)` queries against the User table. Each requires a separate round-trip and scan.
+
+**Fix:** Consolidate into one query using `COUNT(*) FILTER (WHERE ...)` conditional aggregation.
+
+**Files:**
+
+- `src/modules/user/user.repository.ts:231-246`
+
+---
+
+#### 95. Export Redundant Queries (Categories + Two Round-Trips)
+
+**Effort:** Low | **Impact:** Low | **Reported by:** performance-engineer
+
+`exportTransactions` fires a separate `findCategoriesByUser` call even though `findAllForExport` already JOINs category columns. Additionally, when `categoryId` is provided, `findAllForExport` splits into two queries instead of using a subquery.
+
+**Fix:** Remove the redundant `findCategoriesByUser` call. Replace the two-query pattern with a single query using a subquery for `categoryId` filtering.
+
+**Files:**
+
+- `src/modules/transactions/transactions.service.ts:269-271`
+- `src/modules/transactions/transactions.repository.ts:196-209`
+
+---
+
+#### 96. Analytics Cache Keys Unbounded Growth
+
+**Effort:** Low | **Impact:** Low | **Reported by:** performance-engineer
+
+Cache keys include arbitrary `dateFrom`/`dateTo` strings. Any date-range variation creates a new cache entry, wasting Redis memory with very low hit rates.
+
+**Fix:** Normalise date parameters to date-only strings before hashing in `buildCacheKey`.
+
+**Files:**
+
+- `src/modules/transactions-analytics/transactions-analytics.service.ts:59-79`
+- `src/modules/cache/cache-key.utils.ts:10-23`
+
+---
+
+#### 97. Transaction_userId_date_idx DESC vs ASC Mismatch
+
+**Effort:** Low | **Impact:** Low | **Reported by:** performance-engineer
+
+`Transaction_userId_date_idx` is defined as `(userId, date DESC)` but analytics range queries use `gte`/`lte` predicates that benefit from ASC ordering. The planner may use a bitmap scan instead of an efficient index scan.
+
+**Fix:** Change to `(userId, date)` (ascending default). Apply same to `Transaction_userId_currencyCode_date_idx`.
+
+**Files:**
+
+- `src/database/schemas/transactions.ts:52-53`
+
+---
+
+#### 98. Multiple Unsafe `as` Casts Across Codebase
+
+**Effort:** Low | **Impact:** Low | **Reported by:** typescript-pro
+
+~10 instances of `as` casts that suppress type safety: `getCategoryInfo` result casts, `results[j] as PromiseSettledResult`, `req.params as Record`, `create()` returning casts, `parentDefaultTransactionCategoryId as string`, `getSpentAmountForAllActiveBudgets` return cast, and `CacheKeyOptions.params` typed as `object`.
+
+**Fix:** Replace each cast with proper type narrowing, runtime guards, or correct type annotations. See individual files for specific fixes.
+
+**Files:**
+
+- `src/modules/transactions/transactions.repository.ts:488-497`
+- `src/modules/recurring-transactions/recurring-transactions.service.ts:367`
+- `src/modules/audit-log/audit-log.interceptor.ts:32`
+- `src/modules/auth/refresh-token.repository.ts:45`
+- `src/modules/default-transaction-categories/default-transaction-categories.repository.ts:326`
+- `src/modules/budgets/budgets.repository.ts:365`
+- `src/modules/cache/cache-key.utils.ts:7,18`
+
+---
+
+#### 99. Cache Module Name Strings Duplicated Across Modules
+
+**Effort:** Low | **Impact:** Low | **Reported by:** architect-reviewer, nestjs-expert
+
+Cache module name strings are inline constants in service/listener files instead of exported from `*.constants.ts`. Cross-module invalidation (e.g., import service hardcoding `'categories'`) risks typo mismatches.
+
+**Fix:** Move each `CACHE_MODULE` declaration into the respective `*.constants.ts` file and import it in both service and listener.
+
+**Files:**
+
+- `src/modules/budgets/budgets.service.ts:26`
+- `src/modules/user/user.service.ts:27`
+- `src/modules/budgets/budgets-cache.listener.ts:8`
+- `src/modules/transactions-analytics/transactions-analytics-cache.listener.ts:8`
+- `src/modules/transactions/transaction-import.service.ts:88`
+
+---
+
+#### 100. Dead Code: createTransaction Method and Noop Conditional
+
+**Effort:** Low | **Impact:** Low | **Reported by:** refactoring-specialist
+
+`RecurringTransactionsRepository.createTransaction` (singular) is never called — only `createTransactionsBatch` is used. `DefaultTransactionCategoriesService.findAll` has an empty `if` block with only a comment.
+
+**Fix:** Delete `createTransaction` and remove the empty `if` block.
+
+**Files:**
+
+- `src/modules/recurring-transactions/recurring-transactions.repository.ts:394-406`
+- `src/modules/default-transaction-categories/default-transaction-categories.service.ts:26-32`
+
+---
+
+#### 101. Duplicated pause/resume, findDue, and hasUpdates Patterns
+
+**Effort:** Low | **Impact:** Low | **Reported by:** refactoring-specialist
+
+`pause` and `resume` are structurally identical (find, check status, update, invalidate cache). `findDueRecurringTransactions` and `findAllDueRecurringTransactions` differ by one WHERE condition. The `hasUpdates` empty-update guard is copy-pasted in 3 services.
+
+**Fix:** Extract `transitionStatus(id, userId, requiredStatus, targetStatus)` method. Consolidate findDue with optional `userId` parameter. Extract shared `assertHasUpdates(data)` utility.
+
+**Files:**
+
+- `src/modules/recurring-transactions/recurring-transactions.service.ts:228-304`
+- `src/modules/recurring-transactions/recurring-transactions.repository.ts:352-392`
+- `src/modules/transactions/transactions.service.ts:95`
+- `src/modules/budgets/budgets.service.ts:124`
+
+---
+
+#### 102. Identical transaction\<T\> Wrapper in 5 Repositories
+
+**Effort:** Medium | **Impact:** Low | **Reported by:** refactoring-specialist
+
+Every repository has an identical `async transaction<T>(callback)` one-liner delegating to `this.db.transaction(callback)`.
+
+**Fix:** Create a `BaseRepository` abstract class in `src/shared/` that holds `db` and `transaction`, or extract a shared `TransactionRunner` service.
+
+**Files:**
+
+- `src/modules/transactions/transactions.repository.ts:235`
+- `src/modules/recurring-transactions/recurring-transactions.repository.ts:191`
+- `src/modules/transaction-categories/transaction-categories.repository.ts:113`
+- `src/modules/budgets/budgets.repository.ts:78`
+- `src/modules/default-transaction-categories/default-transaction-categories.repository.ts:125`
+
+---
+
+#### 103. ScheduledTasksService Mixes Unrelated Domain Responsibilities
+
+**Effort:** Medium | **Impact:** Low | **Reported by:** nestjs-expert
+
+`ScheduledTasksService` orchestrates tasks from three unrelated domains (auth cleanup, recurring transactions, budget checks) plus operational concerns (heartbeat, startup). Adding a new cron requires importing that module into `ScheduledTasksModule`.
+
+**Fix:** Move domain-specific cron methods into their owning modules. Keep `ScheduledTasksService` only for cross-cutting operational tasks.
+
+**Files:**
+
+- `src/modules/scheduled-tasks/scheduled-tasks.service.ts:1-52`
+
+---
+
+#### 104. AuthController Config Assembly in Constructor
+
+**Effort:** Low | **Impact:** Low | **Reported by:** nestjs-expert
+
+The `AuthController` constructor makes six `configService.get()` calls and stores them as instance fields, with an eslint-disable for `max-params`. Controllers should not assemble configuration.
+
+**Fix:** Extract into a dedicated `AuthCookieConfig` injectable provider and inject it as a single dependency.
+
+**Files:**
+
+- `src/modules/auth/auth.controller.ts:69-90`
+
+---
+
+#### 105. AuditLogInterceptor Records Raw URL Not Structured Resource
+
+**Effort:** Low | **Impact:** Low | **Reported by:** nestjs-expert
+
+The interceptor logs `action: "${method} ${url}"` with no semantic resource type. `AuditLogService.log` supports `resourceType` and `detail` fields that are never populated.
+
+**Fix:** Add a `@AuditAction({ resource: string })` custom decorator. The interceptor reads metadata via `Reflector` and passes it as `resourceType`.
+
+**Files:**
+
+- `src/modules/audit-log/audit-log.interceptor.ts:19,30`
+
+---
+
+#### 106. Dependency Vulnerabilities: flatted and vite
+
+**Effort:** Low | **Impact:** Low | **Reported by:** dependency-manager
+
+`eslint` 10.0.3 transitively depends on `flatted` 3.4.1 (prototype pollution). `vitest` 4.1.0 depends on `vite` 8.0.0 (path traversal). Both are dev dependencies.
+
+**Fix:** Update `eslint` to 10.2.0+ and `vitest` to 4.1.4+ (or remove vitest per #107).
+
+**Files:**
+
+- `package.json:86,99`
+
+---
+
+#### 107. Unused Dependencies: vitest, @nestjs/testing, jiti
+
+**Effort:** Low | **Impact:** Low | **Reported by:** dependency-manager
+
+`vitest`, `@nestjs/testing`, and `jiti` are installed but never imported or used. No test files exist in the project.
+
+**Fix:** Remove all three from devDependencies. Re-add when tests are implemented.
+
+**Files:**
+
+- `package.json:68,91,99`
+
+---
+
+#### 108. AuditLogModule Unnecessary @Global
+
+**Effort:** Low | **Impact:** Low | **Reported by:** architect-reviewer
+
+`AuditLogModule` is `@Global()` but its only cross-module consumer is `AuditLogInterceptor` registered in `AppModule`, which already imports `AuditLogModule`.
+
+**Fix:** Remove the `@Global()` decorator.
+
+**Files:**
+
+- `src/modules/audit-log/audit-log.module.ts:7`
+
+---
+
+## Recommended Execution Order
+
+### Sprint 1 — Security (Batch A)
+
+#69, #70, #71
+
+### Sprint 2 — Database Indexes & Constraints (Batch B)
+
+#75, #76, #77, #79, #80, #92
+
+### Sprint 3 — API Correctness (Batch C)
+
+#72, #73, #74, #85, #86, #89, #90
+
+### Sprint 4 — Architecture (Batch D)
+
+#68, #78, #81, #82, #83, #84
+
+### Sprint 5 — Cleanup & DX (Batch E)
+
+#87, #88, #91, #93, #94, #95, #96, #97, #98, #99, #100, #101, #102, #103, #104, #105, #106, #107, #108
 
 ## Low Priority / Deferred
 
@@ -204,3 +898,6 @@ No documentation for required environment variables beyond the Zod schema. Incre
 | 58   | Missing controller return type annotations                    | Medium   | Medium | P2       | Done   |
 | 59   | Header type casts drop array case                             | Medium   | Low    | P2       | Done   |
 | 61   | Guards barrel re-export violates project convention           | Medium   | Low    | P2       | Done   |
+| 65   | RETURNING order dependency in cloneDefaultCategoriesToUser    | High     | Low    | P1       | Done   |
+| 66   | Admin hard-delete does not invalidate user sessions           | High     | Medium | P1       | Done   |
+| 67   | path-to-regexp ReDoS vulnerability in @nestjs/core            | High     | Low    | P1       | Done   |

--- a/package.json
+++ b/package.json
@@ -108,6 +108,9 @@
       "@nestjs/core",
       "bcrypt",
       "@swc/core"
-    ]
+    ],
+    "overrides": {
+      "path-to-regexp": "8.4.2"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  path-to-regexp: 8.4.2
+
 importers:
   .:
     dependencies:
@@ -5847,10 +5850,10 @@ packages:
       }
     engines: { node: 18 || 20 || >=22 }
 
-  path-to-regexp@8.3.0:
+  path-to-regexp@8.4.2:
     resolution:
       {
-        integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==,
+        integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==,
       }
 
   path-type@4.0.0:
@@ -7987,7 +7990,7 @@ snapshots:
       '@nuxt/opencollective': 0.4.1
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
       tslib: 2.8.1
@@ -8027,7 +8030,7 @@ snapshots:
       cors: 2.8.6
       express: 5.2.1
       multer: 2.1.1
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -8057,7 +8060,7 @@ snapshots:
       '@nestjs/mapped-types': 2.1.0(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
       js-yaml: 4.1.1
       lodash: 4.17.23
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
       reflect-metadata: 0.2.2
       swagger-ui-dist: 5.31.0
     optionalDependencies:
@@ -10366,7 +10369,7 @@ snapshots:
       lru-cache: 11.3.3
       minipass: 7.1.3
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -10597,7 +10600,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 

--- a/src/modules/auth/auth-session.listener.ts
+++ b/src/modules/auth/auth-session.listener.ts
@@ -5,6 +5,7 @@ import {
   PROFILE_EVENTS,
   type ProfileSessionInvalidationEvent,
 } from '@/modules/profile/events/profile.event.js';
+import { USER_EVENTS, type UserHardDeletedEvent } from '@/modules/user/events/user.event.js';
 
 import { TokenService } from './token.service.js';
 
@@ -22,6 +23,22 @@ export class AuthSessionListener {
   @OnEvent(PROFILE_EVENTS.ACCOUNT_DELETED, { async: true })
   async handleAccountDeleted(event: ProfileSessionInvalidationEvent): Promise<void> {
     await this.invalidateSessions(event, 'account deletion');
+  }
+
+  @OnEvent(USER_EVENTS.HARD_DELETED, { async: true })
+  async handleUserHardDeleted(event: UserHardDeletedEvent): Promise<void> {
+    // Admin-triggered hard delete: we only know the target userId, not any
+    // active access-token JTI, so we can only revoke refresh tokens here.
+    // Access tokens expire naturally; the cascade FK deletes refresh tokens
+    // too, but the explicit call documents intent and survives schema changes.
+    try {
+      await this.tokenService.revokeAllRefreshTokens(event.userId);
+    } catch (error) {
+      this.logger.error(
+        `Failed to revoke refresh tokens after hard delete for user ${event.userId}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+    }
   }
 
   private async invalidateSessions(

--- a/src/modules/default-transaction-categories/default-transaction-categories.repository.ts
+++ b/src/modules/default-transaction-categories/default-transaction-categories.repository.ts
@@ -303,19 +303,29 @@ export class DefaultTransactionCategoryRepository {
       const insertedParents = await tx
         .insert(transactionCategories)
         .values(parents.map((p) => ({ userId, name: p.name, type: p.type })))
-        .returning({ id: transactionCategories.id, name: transactionCategories.name });
+        .returning({
+          id: transactionCategories.id,
+          name: transactionCategories.name,
+          type: transactionCategories.type,
+        });
 
-      // PostgreSQL guarantees that RETURNING rows are returned in insertion order,
-      // so insertedParents[i] corresponds to parents[i] and the mapping is stable.
-      const idMap = new Map<string, string>(
-        parents
-          .map((p, i) => {
-            const inserted = insertedParents[i];
+      // Build idMap by (name, type) natural key rather than positional index.
+      // PostgreSQL does not guarantee RETURNING order, and parallel workers or
+      // triggers could reorder rows and silently corrupt the category tree.
+      // (name, type) is unique within the parents set because defaults enforce
+      // uniqueness on (name, type, parent=NULL).
+      const insertedByKey = new Map<string, string>();
+      for (const inserted of insertedParents) {
+        insertedByKey.set(`${inserted.type}::${inserted.name}`, inserted.id);
+      }
 
-            return inserted ? ([p.id, inserted.id] as [string, string]) : null;
-          })
-          .filter((entry): entry is [string, string] => entry !== null),
-      );
+      const idMap = new Map<string, string>();
+      for (const parent of parents) {
+        const newId = insertedByKey.get(`${parent.type}::${parent.name}`);
+        if (newId) {
+          idMap.set(parent.id, newId);
+        }
+      }
 
       if (children.length === 0) {
         return;

--- a/src/modules/onboarding/dtos/complete-onboarding.dto.ts
+++ b/src/modules/onboarding/dtos/complete-onboarding.dto.ts
@@ -12,7 +12,7 @@ import {
 import { CURRENCY_CODES, type CurrencyCode } from '@/shared/enums/currency-code.enum.js';
 
 export class CompleteOnboardingDto {
-  @ApiProperty({ example: 'USD' })
+  @ApiProperty({ example: 'USD', type: String, enum: CURRENCY_CODES, enumName: 'CurrencyCode' })
   @IsStringField()
   @IsNotEmptyField({ message: 'baseCurrencyCode is required' })
   @IsInField([...CURRENCY_CODES], { message: 'Invalid currency code' })

--- a/src/modules/transactions/transaction-import.service.ts
+++ b/src/modules/transactions/transaction-import.service.ts
@@ -20,7 +20,7 @@ import type { CreateTransactionData } from './transactions.repository.js';
 import type { ImportResult, ParsedTransactionRow } from './transactions.types.js';
 import { CACHE_MODULE } from './transactions.constants.js';
 
-const MAX_IMPORT_ROWS = 1000;
+const MAX_IMPORT_ROWS = 3000;
 const TYPE_MAP: Record<string, TransactionType> = {
   expense: 'EXPENSE',
   income: 'INCOME',

--- a/src/modules/user/dtos/user-response.dto.ts
+++ b/src/modules/user/dtos/user-response.dto.ts
@@ -3,7 +3,9 @@ import { ApiProperty } from '@nestjs/swagger';
 import type { AuthProvider } from '@/shared/enums/auth-provider.enum.js';
 import { AUTH_PROVIDERS } from '@/shared/enums/auth-provider.enum.js';
 import type { CountryCode } from '@/shared/enums/country-code.enum.js';
+import { COUNTRY_CODES } from '@/shared/enums/country-code.enum.js';
 import type { CurrencyCode } from '@/shared/enums/currency-code.enum.js';
+import { CURRENCY_CODES } from '@/shared/enums/currency-code.enum.js';
 import type { UserRole } from '@/shared/enums/role.enum.js';
 import { ROLES } from '@/shared/enums/role.enum.js';
 
@@ -17,6 +19,7 @@ export class UserResponseDto {
   @ApiProperty({
     description: 'User role',
     example: 'USER',
+    type: String,
     enum: ROLES,
     enumName: 'UserRole',
   })
@@ -26,6 +29,7 @@ export class UserResponseDto {
     description:
       'Derived auth provider: LOCAL if the user has a password identity, else the earliest-created social identity. Null only when no authentication identity is associated with the user.',
     example: 'LOCAL',
+    type: String,
     enum: AUTH_PROVIDERS,
     enumName: 'AuthProvider',
     nullable: true,
@@ -38,22 +42,38 @@ export class UserResponseDto {
   @ApiProperty({
     description: 'Country code (ISO 3166-1 alpha-3)',
     example: 'USA',
+    type: String,
+    enum: COUNTRY_CODES,
+    enumName: 'CountryCode',
     nullable: true,
   })
   countryCode: CountryCode | null;
 
-  @ApiProperty({ description: 'Base currency code (ISO 4217)', example: 'USD', nullable: true })
+  @ApiProperty({
+    description: 'Base currency code (ISO 4217)',
+    example: 'USD',
+    type: String,
+    enum: CURRENCY_CODES,
+    enumName: 'CurrencyCode',
+    nullable: true,
+  })
   baseCurrencyCode: CurrencyCode | null;
 
   @ApiProperty({ description: 'Whether onboarding is completed', example: false })
   onboardingCompleted: boolean;
 
-  @ApiProperty({ description: 'Last known IP address', example: '192.168.1.1', nullable: true })
+  @ApiProperty({
+    description: 'Last known IP address',
+    example: '192.168.1.1',
+    type: String,
+    nullable: true,
+  })
   ipAddress: string | null;
 
   @ApiProperty({
     description: 'Last known user agent',
     example: 'Mozilla/5.0...',
+    type: String,
     nullable: true,
   })
   userAgent: string | null;

--- a/src/modules/user/events/user.event.ts
+++ b/src/modules/user/events/user.event.ts
@@ -1,0 +1,11 @@
+export const USER_EVENTS = {
+  HARD_DELETED: 'user.hard-deleted',
+} as const;
+
+export class UserHardDeletedEvent {
+  readonly userId: string;
+
+  constructor(userId: string) {
+    this.userId = userId;
+  }
+}

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import * as bcrypt from 'bcrypt';
 
 import type { User } from '@/database/schemas/users.js';
@@ -16,6 +17,7 @@ import { ErrorCode } from '@/shared/enums/error-code.enum.js';
 import { hasRequiredRole } from '@/shared/enums/role.enum.js';
 import type { UserRole } from '@/shared/enums/role.enum.js';
 
+import { USER_EVENTS, UserHardDeletedEvent } from './events/user.event.js';
 import { IdentityRepository } from './identity.repository.js';
 import type { IdentityWithUser } from './identity.repository.js';
 import { UserRepository } from './user.repository.js';
@@ -32,10 +34,12 @@ const CACHE_MODULE = 'users';
 
 @Injectable()
 export class UserService {
+  // eslint-disable-next-line @typescript-eslint/max-params
   constructor(
     private readonly userRepository: UserRepository,
     private readonly identityRepository: IdentityRepository,
     private readonly cacheService: CacheService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async findByEmail(email: string): Promise<User | null> {
@@ -187,6 +191,8 @@ export class UserService {
     }
 
     await this.cacheService.delByPrefix(buildCachePrefix(CACHE_MODULE));
+
+    await this.eventEmitter.emitAsync(USER_EVENTS.HARD_DELETED, new UserHardDeletedEvent(id));
   }
 
   async getSummary(): Promise<UserSummary> {


### PR DESCRIPTION
## Summary

- **#65 RETURNING order dependency (High):** `cloneDefaultCategoriesToUser` previously relied on positional alignment between the input array and the `RETURNING` rows when cloning default categories. Postgres does not guarantee this order. Rewrote the parent-ID map to join on the `(type, name)` natural key, which is unique within the defaults table.
- **#66 Admin hard-delete does not invalidate sessions (High):** Added `USER_EVENTS.HARD_DELETED` event. `UserService.delete()` now emits it after a successful `hardDelete`. `AuthSessionListener` has a new handler that revokes all refresh tokens for the target user. Access-token JTIs are unknown to the admin, so the listener only clears refresh tokens (access tokens expire naturally; refresh tokens also cascade via FK).
- **#67 path-to-regexp ReDoS GHSA-36xv-jgw5-4q75 (High):** Pinned `path-to-regexp` to `8.4.2` via `pnpm.overrides`. Verified via `pnpm why` that all transitive paths (nestjs/core, platform-express, express/router, event-emitter, schedule) now resolve 8.4.2.
- **Swagger DTO typing:** `UserResponseDto.countryCode`/`baseCurrencyCode`/`ipAddress`/`userAgent` and `CompleteOnboardingDto.baseCurrencyCode` now declare explicit `type: String` (plus `enum`/`enumName` where applicable), matching the `ProfileResponseDto` pattern. Fixes `@hey-api/openapi-ts` emitting `{ [key: string]: unknown }` for TypeScript string-literal union types.
- **Transactions import:** Raised `MAX_IMPORT_ROWS` from 1000 to 3000.

## Test plan

- [ ] Register a new user and confirm default categories clone correctly with intact parent/child relationships (covers #65)
- [ ] Seed DB with defaults where sibling parent categories share a name across different types (EXPENSE vs INCOME) and re-run registration to confirm natural-key lookup still maps correctly
- [ ] As admin, log in as user B (separate session), then `DELETE /users/:id` for user B from admin session; verify user B's refresh tokens are removed from DB and `POST /auth/refresh` with B's token returns 401 (covers #66)
- [ ] Confirm admin's own session remains valid after deleting another user
- [ ] Run `pnpm why path-to-regexp` and confirm every resolution is `8.4.2` (covers #67)
- [ ] Regenerate the API client via `@hey-api/openapi-ts` and confirm `UserResponseDto.countryCode` is typed as `CountryCode | null` (not `{ [key: string]: unknown }`)
- [ ] Import a CSV with >1000 but ≤3000 rows and confirm it processes instead of being rejected
- [ ] `pnpm check-types`, `pnpm lint`, `pnpm format:check` pass

Closes TRACK-57

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event-driven token revocation for hard-deleted user accounts.

* **Improvements**
  * Increased maximum import file size from 1,000 to 3,000 rows.
  * Enhanced API documentation with improved schema definitions for enums and data types.

* **Bug Fixes**
  * Fixed dependency resolution for improved package stability.

* **Documentation**
  * Updated improvement tracking with expanded findings and completed fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->