### PR TITLE
fix: p2 security, db constraints, and api correctness findings (TRACK-60)

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -9,50 +9,35 @@
 
 ## Active Findings
 
-| #   | Priority | Finding                                                        | Effort | Impact | Agent(s)               | Status |
-| --- | -------- | -------------------------------------------------------------- | ------ | ------ | ---------------------- | ------ |
-| 15  | P1       | No API versioning strategy                                     | Medium | High   | api-designer           | Todo   |
-| 68  | P2       | Cross-module repository writes bypass service layer            | Medium | Medium | architect, nestjs      | Todo   |
-| 69  | P2       | existsByEmail counts soft-deleted users                        | Low    | Medium | security-auditor       | Todo   |
-| 70  | P2       | Admin can hard-delete own account                              | Low    | Medium | security-auditor       | Todo   |
-| 71  | P2       | socialAuthRedirectUrl as string without runtime guard          | Low    | Medium | security, typescript   | Todo   |
-| 72  | P2       | Validation errors documented as 400 but pipe throws 422        | Low    | Medium | api-designer           | Todo   |
-| 73  | P2       | BudgetResponseDto.endDate non-nullable but column optional     | Low    | Medium | api-designer           | Todo   |
-| 74  | P2       | POST /recurring-transactions/process lacks rate limiting       | Low    | Medium | api-designer           | Todo   |
-| 75  | P2       | Missing CHECK positive amount on Budget + RecurringTransaction | Low    | Medium | postgres-pro           | Todo   |
-| 76  | P2       | Missing composite index (userId, status) on Budget             | Low    | Medium | postgres-pro           | Todo   |
-| 77  | P2       | Verification table no unique constraint on identifier          | Low    | Medium | postgres-pro           | Todo   |
-| 78  | P2       | SQL alias-based GROUP BY/ORDER BY fragile pattern              | Low    | Medium | perf, postgres, db-opt | Todo   |
-| 79  | P2       | getSpentAmount no partial index for EXPENSE filter             | Low    | Medium | database-optimizer     | Todo   |
-| 80  | P2       | findOverlapping budget no composite index                      | Low    | Medium | database-optimizer     | Todo   |
-| 81  | P2       | bulkUpdateStatuses TOCTOU — no row lock                        | Medium | Medium | database-optimizer     | Todo   |
-| 82  | P2       | Redundant getCategoryInfo query per recurring iteration        | Medium | Medium | performance-engineer   | Todo   |
-| 83  | P2       | Duplicated getCategoryInfo method across repositories          | Low    | Medium | refactoring-specialist | Todo   |
-| 84  | P2       | Repeated field-by-field update construction in repos           | Medium | Medium | refactoring-specialist | Todo   |
-| 85  | P2       | Unsafe as casts on .returning() suppress Drizzle inference     | Low    | Medium | typescript-pro         | Todo   |
-| 86  | P2       | Filters/interceptors dual-registration pattern                 | Low    | Medium | nestjs-expert          | Todo   |
-| 87  | P3       | Login log writes fire-and-forget no error handling             | Low    | Low    | security-auditor       | Todo   |
-| 88  | P3       | Password change allows same password                           | Low    | Low    | security-auditor       | Todo   |
-| 89  | P3       | DELETE endpoints return 200 instead of 204                     | Low    | Low    | api-designer           | Todo   |
-| 90  | P3       | Missing Swagger response types on auth/providers + onboarding  | Low    | Low    | api-designer           | Todo   |
-| 91  | P3       | Import errors unstructured string array                        | Medium | Low    | api-designer           | Todo   |
-| 92  | P3       | LoginLog.email + KnownDevice.userId missing indexes            | Low    | Low    | postgres, db-opt       | Todo   |
-| 93  | P3       | Verification table no cleanup + no expiresAt index             | Low    | Low    | database-optimizer     | Todo   |
-| 94  | P3       | getUserSummary three separate COUNT queries                    | Low    | Low    | perf, db-opt           | Todo   |
-| 95  | P3       | Export redundant queries (categories + two round-trips)        | Low    | Low    | performance-engineer   | Todo   |
-| 96  | P3       | Analytics cache keys unbounded growth                          | Low    | Low    | performance-engineer   | Todo   |
-| 97  | P3       | Transaction_userId_date_idx DESC vs ASC mismatch               | Low    | Low    | performance-engineer   | Todo   |
-| 98  | P3       | Multiple unsafe as casts across codebase                       | Low    | Low    | typescript-pro         | Todo   |
-| 99  | P3       | Cache module name strings duplicated across modules            | Low    | Low    | architect, nestjs      | Todo   |
-| 100 | P3       | Dead code: createTransaction method + noop conditional         | Low    | Low    | refactoring-specialist | Todo   |
-| 101 | P3       | Duplicated pause/resume + findDue + hasUpdates patterns        | Low    | Low    | refactoring-specialist | Todo   |
-| 102 | P3       | Identical transaction\<T\> wrapper in 5 repositories           | Medium | Low    | refactoring-specialist | Todo   |
-| 103 | P3       | ScheduledTasksService mixes unrelated responsibilities         | Medium | Low    | nestjs-expert          | Todo   |
-| 104 | P3       | AuthController config assembly in constructor                  | Low    | Low    | nestjs-expert          | Todo   |
-| 105 | P3       | AuditLogInterceptor records raw URL not structured             | Low    | Low    | nestjs-expert          | Todo   |
-| 106 | P3       | Dependency vulnerabilities: flatted + vite                     | Low    | Low    | dependency-manager     | Todo   |
-| 107 | P3       | Unused dependencies: vitest, @nestjs/testing, jiti             | Low    | Low    | dependency-manager     | Todo   |
-| 108 | P3       | AuditLogModule unnecessary @Global                             | Low    | Low    | architect-reviewer     | Todo   |
+| #   | Priority | Finding                                                       | Effort | Impact | Agent(s)               | Status |
+| --- | -------- | ------------------------------------------------------------- | ------ | ------ | ---------------------- | ------ |
+| 15  | P1       | No API versioning strategy                                    | Medium | High   | api-designer           | Todo   |
+| 68  | P2       | Cross-module repository writes bypass service layer           | Medium | Medium | architect, nestjs      | Todo   |
+| 81  | P2       | bulkUpdateStatuses TOCTOU — no row lock                       | Medium | Medium | database-optimizer     | Todo   |
+| 82  | P2       | Redundant getCategoryInfo query per recurring iteration       | Medium | Medium | performance-engineer   | Todo   |
+| 84  | P2       | Repeated field-by-field update construction in repos          | Medium | Medium | refactoring-specialist | Todo   |
+| 87  | P3       | Login log writes fire-and-forget no error handling            | Low    | Low    | security-auditor       | Todo   |
+| 88  | P3       | Password change allows same password                          | Low    | Low    | security-auditor       | Todo   |
+| 89  | P3       | DELETE endpoints return 200 instead of 204                    | Low    | Low    | api-designer           | Todo   |
+| 90  | P3       | Missing Swagger response types on auth/providers + onboarding | Low    | Low    | api-designer           | Todo   |
+| 91  | P3       | Import errors unstructured string array                       | Medium | Low    | api-designer           | Todo   |
+| 92  | P3       | LoginLog.email + KnownDevice.userId missing indexes           | Low    | Low    | postgres, db-opt       | Todo   |
+| 93  | P3       | Verification table no cleanup + no expiresAt index            | Low    | Low    | database-optimizer     | Todo   |
+| 94  | P3       | getUserSummary three separate COUNT queries                   | Low    | Low    | perf, db-opt           | Todo   |
+| 95  | P3       | Export redundant queries (categories + two round-trips)       | Low    | Low    | performance-engineer   | Todo   |
+| 96  | P3       | Analytics cache keys unbounded growth                         | Low    | Low    | performance-engineer   | Todo   |
+| 97  | P3       | Transaction_userId_date_idx DESC vs ASC mismatch              | Low    | Low    | performance-engineer   | Todo   |
+| 98  | P3       | Multiple unsafe as casts across codebase                      | Low    | Low    | typescript-pro         | Todo   |
+| 99  | P3       | Cache module name strings duplicated across modules           | Low    | Low    | architect, nestjs      | Todo   |
+| 100 | P3       | Dead code: createTransaction method + noop conditional        | Low    | Low    | refactoring-specialist | Todo   |
+| 101 | P3       | Duplicated pause/resume + findDue + hasUpdates patterns       | Low    | Low    | refactoring-specialist | Todo   |
+| 102 | P3       | Identical transaction\<T\> wrapper in 5 repositories          | Medium | Low    | refactoring-specialist | Todo   |
+| 103 | P3       | ScheduledTasksService mixes unrelated responsibilities        | Medium | Low    | nestjs-expert          | Todo   |
+| 104 | P3       | AuthController config assembly in constructor                 | Low    | Low    | nestjs-expert          | Todo   |
+| 105 | P3       | AuditLogInterceptor records raw URL not structured            | Low    | Low    | nestjs-expert          | Todo   |
+| 106 | P3       | Dependency vulnerabilities: flatted + vite                    | Low    | Low    | dependency-manager     | Todo   |
+| 107 | P3       | Unused dependencies: vitest, @nestjs/testing, jiti            | Low    | Low    | dependency-manager     | Todo   |
+| 108 | P3       | AuditLogModule unnecessary @Global                            | Low    | Low    | architect-reviewer     | Todo   |
 
 ---
 
@@ -98,180 +83,6 @@ This bypasses business rules, validation, and cache invalidation. `TransactionCa
 
 ---
 
-#### 69. existsByEmail Counts Soft-Deleted Users Blocking Re-Registration
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** security-auditor
-
-`existsByEmail` queries without filtering `isNull(users.deletedAt)`. When a user soft-deletes their account, their email becomes permanently locked. This is inconsistent with `findByEmail` which correctly filters soft-deleted records, and creates a DoS vector.
-
-**Fix:** Add `isNull(users.deletedAt)` to the `where` clause of `existsByEmail`.
-
-**Files:**
-
-- `src/modules/user/user.repository.ts:177-183`
-
----
-
-#### 70. Admin Can Hard-Delete Own Account
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** security-auditor
-
-The admin `DELETE /users/:id` endpoint has no self-deletion guard. An admin can permanently delete their own account, potentially leaving the system with no administrators. Unlike `assignRole` which explicitly blocks self-modification, `delete` has no such check.
-
-**Fix:** Add a self-deletion guard in `UserService.delete()` that compares the target `id` against the actor's `id`, rejecting with a `ForbiddenException` if they match.
-
-**Files:**
-
-- `src/modules/user/user.controller.ts:119-128`
-- `src/modules/user/user.service.ts:160-169`
-
----
-
-#### 71. socialAuthRedirectUrl `as string` Without Runtime Guard
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** security-auditor, typescript-pro
-
-`this.socialAuthRedirectUrl` is typed `string | undefined` but cast to `string` with `as string` in `handleSocialCallback`. If undefined at runtime, `new URL(redirectUrl)` throws an uncaught TypeError. The `verifyEmail` method correctly validates with an explicit null check.
-
-**Fix:** Replace `as string` with a runtime guard: `if (!this.socialAuthRedirectUrl) throw new InternalServerErrorException('Social auth redirect URL is not configured');`.
-
-**Files:**
-
-- `src/modules/auth/auth.controller.ts:355`
-
----
-
-#### 72. Validation Errors Documented as 400 but Pipe Throws 422
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** api-designer
-
-The global `ValidationPipe` is configured with `errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY` (422), but every controller documents `@ApiResponse({ status: 400, description: 'Validation error' })`. Clients relying on the Swagger spec will not handle 422 correctly.
-
-**Fix:** Replace all `@ApiResponse({ status: 400, description: 'Validation error' })` with `@ApiResponse({ status: 422, description: 'Validation error' })`. Reserve 400 only for explicit `BadRequestException` throws.
-
-**Files:**
-
-- `src/app/config/validation.config.ts:12-14`
-- All controllers with `@ApiResponse({ status: 400 })`
-
----
-
-#### 73. BudgetResponseDto.endDate Non-Nullable but Column Optional
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** api-designer
-
-`CreateBudgetDto.endDate` and `UpdateBudgetDto.endDate` are `@IsOptional()`, so a budget may lack an end date. Yet `BudgetResponseDto.endDate` is declared as non-nullable `Date`, misleading clients.
-
-**Fix:** Change to `endDate: Date | null` and add `{ type: Date, nullable: true }` to its `@ApiProperty` decorator.
-
-**Files:**
-
-- `src/modules/budgets/dtos/budget-response.dto.ts:44-45`
-
----
-
-#### 74. POST /recurring-transactions/process Lacks Rate Limiting
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** api-designer
-
-The `process` endpoint triggers bulk recurring transaction processing and is admin-only, but has no `@Throttle` decorator. A compromised admin token could invoke it in a tight loop causing mass duplicate transactions.
-
-**Fix:** Add `@Throttle({ default: { limit: 5, ttl: 60000 } })` to the `process` method.
-
-**Files:**
-
-- `src/modules/recurring-transactions/recurring-transactions.controller.ts:175-184`
-
----
-
-#### 75. Missing CHECK Positive Amount on Budget and RecurringTransaction
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** postgres-pro
-
-The `Transaction` table has `CHECK (amount > 0)` but `Budget` and `RecurringTransaction` tables have no equivalent constraint. Zero or negative amounts are insertable via SQL.
-
-**Fix:** Add `check('Budget_amount_positive', sql\`amount > 0\`)`and`check('RecurringTransaction_amount_positive', sql\`amount > 0\`)`to the respective table constraints. Run`pnpm db:generate && pnpm db:migrate`.
-
-**Files:**
-
-- `src/database/schemas/budgets.ts:28,43-52`
-- `src/database/schemas/recurring-transactions.ts:34,55-71`
-
----
-
-#### 76. Missing Composite Index (userId, status) on Budget
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** postgres-pro
-
-User-scoped budget queries filter by `userId` + `status` but only have separate single-column indexes. The nightly cron and user-facing list queries fall back to bitmap-and on two indexes.
-
-**Fix:** Add `index('Budget_userId_status_idx').on(table.userId, table.status)` to the Budget schema.
-
-**Files:**
-
-- `src/database/schemas/budgets.ts:43-52`
-- `src/modules/budgets/budgets.repository.ts:306-319`
-
----
-
-#### 77. Verification Table No Unique Constraint on Identifier
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** postgres-pro
-
-Multiple concurrent requests can insert duplicate verification rows for the same identifier. A lookup returns whichever row is first, making prior tokens stale without invalidation.
-
-**Fix:** Replace the plain `index` on `identifier` with `uniqueIndex('Verification_identifier_key').on(table.identifier)`.
-
-**Files:**
-
-- `src/database/schemas/verifications.ts:3-19`
-
----
-
-#### 78. SQL Alias-Based GROUP BY/ORDER BY Fragile Pattern
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** performance-engineer, postgres-pro, database-optimizer
-
-`getDailyTotals` groups by alias `day`, and `getCategoryBreakdown`/`getTopCategories` order by alias `total`. Using aliases in GROUP BY/ORDER BY is PostgreSQL-specific, fragile if aliases change, and prevents the planner from reusing computed expressions efficiently.
-
-**Fix:** Replace alias references with the full expressions: `.groupBy(sql\`${transactions.date}::date\`)` and `.orderBy(desc(sql\`SUM(${transactions.amount})\`))`.
-
-**Files:**
-
-- `src/modules/transactions-analytics/transactions-analytics.repository.ts:113,177,195,201-202`
-
----
-
-#### 79. getSpentAmount No Partial Index for EXPENSE Filter
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** database-optimizer
-
-`getSpentAmount` queries with `type = 'EXPENSE'` but the existing `Transaction_userId_currencyCode_date_idx` doesn't include `type`. PostgreSQL re-filters all rows after the index scan.
-
-**Fix:** Add a partial composite index `ON "Transaction" ("userId", "currencyCode", "date" DESC) WHERE type = 'EXPENSE'`.
-
-**Files:**
-
-- `src/database/schemas/transactions.ts:45-64`
-- `src/modules/budgets/budgets.repository.ts:275-303`
-
----
-
-#### 80. findOverlapping Budget No Composite Index
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** database-optimizer
-
-`findOverlapping` filters `userId + currencyCode + startDate + endDate + categoryId` but no composite index covers this combination.
-
-**Fix:** Add `index('Budget_userId_currencyCode_startDate_endDate_idx').on(table.userId, table.currencyCode, table.startDate, table.endDate)`.
-
-**Files:**
-
-- `src/modules/budgets/budgets.repository.ts:232-273`
-- `src/database/schemas/budgets.ts:43-52`
-
----
-
 #### 81. bulkUpdateStatuses TOCTOU — No Row Lock
 
 **Effort:** Medium | **Impact:** Medium | **Reported by:** database-optimizer
@@ -300,21 +111,6 @@ Both `create` and `update` in `RecurringTransactionsRepository` call `getCategor
 
 ---
 
-#### 83. Duplicated getCategoryInfo Method Across Repositories
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** refactoring-specialist
-
-The `getCategoryInfo` private method is copy-pasted identically between `TransactionRepository` and `RecurringTransactionsRepository`.
-
-**Fix:** Extract a shared utility function `fetchCategoryJoinColumns(categoryId, db)` into `src/shared/utils/`.
-
-**Files:**
-
-- `src/modules/transactions/transactions.repository.ts:487-506`
-- `src/modules/recurring-transactions/recurring-transactions.repository.ts:430-449`
-
----
-
 #### 84. Repeated Field-by-Field Update Construction in Repositories
 
 **Effort:** Medium | **Impact:** Medium | **Reported by:** refactoring-specialist
@@ -329,36 +125,6 @@ Every repository `update` method manually checks each field with `if (data.X !==
 - `src/modules/recurring-transactions/recurring-transactions.repository.ts:300-334`
 - `src/modules/budgets/budgets.repository.ts:182-198`
 - `src/modules/user/user.repository.ts:316-333`
-
----
-
-#### 85. Unsafe `as` Casts on .returning() Suppress Drizzle Inference
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** typescript-pro
-
-Both `TransactionRepository.update()` and `RecurringTransactionsRepository.update()` cast `.returning()` results to `(typeof table.$inferSelect)[]`, discarding Drizzle's own structural inference and masking potential schema mismatches.
-
-**Fix:** Remove the casts. Type the `updates` variable properly and let Drizzle infer the `.returning()` result. Use `satisfies` if stricter narrowing is needed.
-
-**Files:**
-
-- `src/modules/transactions/transactions.repository.ts:316-320`
-- `src/modules/recurring-transactions/recurring-transactions.repository.ts:336-340`
-
----
-
-#### 86. Filters/Interceptors Dual-Registration Pattern
-
-**Effort:** Low | **Impact:** Medium | **Reported by:** nestjs-expert
-
-`AllExceptionsFilter`, `ProblemDetailsFilter`, `PaginationLinkInterceptor`, `RequestContextInterceptor`, and `TimeoutInterceptor` are listed as bare class providers in `AppModule`, then retrieved via `app.get(...)` in `main.ts` for global registration. Only `AuditLogInterceptor` uses the correct `APP_INTERCEPTOR` token pattern.
-
-**Fix:** Register each via its respective token (`APP_FILTER`, `APP_INTERCEPTOR`) using `{ provide: APP_FILTER, useClass: ... }` and remove the manual `app.get(...)` calls from `main.ts`.
-
-**Files:**
-
-- `src/app.module.ts:89-103`
-- `src/main.ts:44-50`
 
 ---
 
@@ -901,3 +667,18 @@ No documentation for required environment variables beyond the Zod schema. Incre
 | 65   | RETURNING order dependency in cloneDefaultCategoriesToUser    | High     | Low    | P1       | Done   |
 | 66   | Admin hard-delete does not invalidate user sessions           | High     | Medium | P1       | Done   |
 | 67   | path-to-regexp ReDoS vulnerability in @nestjs/core            | High     | Low    | P1       | Done   |
+| 69   | existsByEmail counts soft-deleted users                       | Medium   | Low    | P2       | Done   |
+| 70   | Admin can hard-delete own account                             | Medium   | Low    | P2       | Done   |
+| 71   | socialAuthRedirectUrl as string without runtime guard         | Medium   | Low    | P2       | Done   |
+| 72   | Validation errors documented as 400 but pipe throws 422       | Medium   | Low    | P2       | Done   |
+| 73   | BudgetResponseDto.endDate non-nullable but column optional    | Medium   | Low    | P2       | N/A    |
+| 74   | POST /recurring-transactions/process lacks rate limiting      | Medium   | Low    | P2       | Done   |
+| 75   | Missing CHECK positive amount on Budget+RecurringTransaction  | Medium   | Low    | P2       | Done   |
+| 76   | Missing composite index (userId, status) on Budget            | Medium   | Low    | P2       | Done   |
+| 77   | Verification table no unique constraint on identifier         | Medium   | Low    | P2       | Done   |
+| 78   | SQL alias-based GROUP BY/ORDER BY fragile pattern             | Medium   | Low    | P2       | Done   |
+| 79   | getSpentAmount no partial index for EXPENSE filter            | Medium   | Low    | P2       | Done   |
+| 80   | findOverlapping budget no composite index                     | Medium   | Low    | P2       | Done   |
+| 83   | Duplicated getCategoryInfo method across repositories         | Medium   | Low    | P2       | Done   |
+| 85   | Unsafe as casts on .returning() suppress Drizzle inference    | Medium   | Low    | P2       | Done   |
+| 86   | Filters/interceptors dual-registration pattern                | Medium   | Low    | P2       | Done   |

--- a/drizzle/0022_crazy_salo.sql
+++ b/drizzle/0022_crazy_salo.sql
@@ -1,0 +1,7 @@
+DROP INDEX "Verification_identifier_idx";--> statement-breakpoint
+CREATE INDEX "Budget_userId_status_idx" ON "Budget" USING btree ("userId","status");--> statement-breakpoint
+CREATE INDEX "Budget_userId_currencyCode_startDate_endDate_idx" ON "Budget" USING btree ("userId","currencyCode","startDate","endDate");--> statement-breakpoint
+CREATE INDEX "Transaction_userId_currencyCode_date_expense_idx" ON "Transaction" USING btree ("userId","currencyCode","date" DESC NULLS LAST) WHERE type = 'EXPENSE';--> statement-breakpoint
+CREATE UNIQUE INDEX "Verification_identifier_key" ON "Verification" USING btree ("identifier");--> statement-breakpoint
+ALTER TABLE "Budget" ADD CONSTRAINT "Budget_amount_positive" CHECK ("Budget"."amount" > 0);--> statement-breakpoint
+ALTER TABLE "RecurringTransaction" ADD CONSTRAINT "RecurringTransaction_amount_positive" CHECK ("RecurringTransaction"."amount" > 0);

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,1949 @@
+{
+  "id": "714986cc-f0a3-4da6-a449-4e44f4b5de49",
+  "prevId": "abe4d022-67f9-439e-a1aa-f24353d9cf2f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.AuditLog": {
+      "name": "AuditLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AuditLog_actorId_createdAt_idx": {
+          "name": "AuditLog_actorId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_createdAt_idx": {
+          "name": "AuditLog_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_action_idx": {
+          "name": "AuditLog_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Budget": {
+      "name": "Budget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "BudgetPeriod",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "BudgetStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Budget_userId_idx": {
+          "name": "Budget_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_categoryId_idx": {
+          "name": "Budget_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_status_idx": {
+          "name": "Budget_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_startDate_endDate_idx": {
+          "name": "Budget_startDate_endDate_idx",
+          "columns": [
+            {
+              "expression": "startDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_status_endDate_idx": {
+          "name": "Budget_status_endDate_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status IN ('ACTIVE', 'EXCEEDED')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_userId_status_idx": {
+          "name": "Budget_userId_status_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Budget_userId_currencyCode_startDate_endDate_idx": {
+          "name": "Budget_userId_currencyCode_startDate_endDate_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currencyCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Budget_userId_User_id_fk": {
+          "name": "Budget_userId_User_id_fk",
+          "tableFrom": "Budget",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Budget_categoryId_TransactionCategory_id_fk": {
+          "name": "Budget_categoryId_TransactionCategory_id_fk",
+          "tableFrom": "Budget",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["categoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Budget_endDate_after_startDate": {
+          "name": "Budget_endDate_after_startDate",
+          "value": "\"endDate\" > \"startDate\""
+        },
+        "Budget_amount_positive": {
+          "name": "Budget_amount_positive",
+          "value": "\"Budget\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.DefaultTransactionCategory": {
+      "name": "DefaultTransactionCategory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentDefaultTransactionCategoryId": {
+          "name": "parentDefaultTransactionCategoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "DefaultTransactionCategory_name_type_parentDefaultTransactionCategoryId_key": {
+          "name": "DefaultTransactionCategory_name_type_parentDefaultTransactionCategoryId_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentDefaultTransactionCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DefaultTransactionCategory_type_idx": {
+          "name": "DefaultTransactionCategory_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DefaultTransactionCategory_parentDefaultTransactionCategoryId_idx": {
+          "name": "DefaultTransactionCategory_parentDefaultTransactionCategoryId_idx",
+          "columns": [
+            {
+              "expression": "parentDefaultTransactionCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DefaultTransactionCategory_parentDefaultTransactionCategoryId_DefaultTransactionCategory_id_fk": {
+          "name": "DefaultTransactionCategory_parentDefaultTransactionCategoryId_DefaultTransactionCategory_id_fk",
+          "tableFrom": "DefaultTransactionCategory",
+          "tableTo": "DefaultTransactionCategory",
+          "columnsFrom": ["parentDefaultTransactionCategoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KnownDevice": {
+      "name": "KnownDevice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstSeenAt": {
+          "name": "firstSeenAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "KnownDevice_userId_User_id_fk": {
+          "name": "KnownDevice_userId_User_id_fk",
+          "tableFrom": "KnownDevice",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "KnownDevice_userId_ipAddress_userAgent_unique": {
+          "name": "KnownDevice_userId_ipAddress_userAgent_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userId", "ipAddress", "userAgent"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LoginLog": {
+      "name": "LoginLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "LoginStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failReason": {
+          "name": "failReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LoginLog_userId_createdAt_idx": {
+          "name": "LoginLog_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LoginLog_userId_User_id_fk": {
+          "name": "LoginLog_userId_User_id_fk",
+          "tableFrom": "LoginLog",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecurringTransaction": {
+      "name": "RecurringTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "RecurringFrequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextOccurrenceDate": {
+          "name": "nextOccurrenceDate",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "RecurringTransactionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RecurringTransaction_userId_idx": {
+          "name": "RecurringTransaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_categoryId_idx": {
+          "name": "RecurringTransaction_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_status_nextOccurrenceDate_idx": {
+          "name": "RecurringTransaction_status_nextOccurrenceDate_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextOccurrenceDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecurringTransaction_type_idx": {
+          "name": "RecurringTransaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecurringTransaction_userId_User_id_fk": {
+          "name": "RecurringTransaction_userId_User_id_fk",
+          "tableFrom": "RecurringTransaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RecurringTransaction_userId_categoryId_TransactionCategory_userId_id_fk": {
+          "name": "RecurringTransaction_userId_categoryId_TransactionCategory_userId_id_fk",
+          "tableFrom": "RecurringTransaction",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["userId", "categoryId"],
+          "columnsTo": ["userId", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "RecurringTransaction_interval_gt_0_chk": {
+          "name": "RecurringTransaction_interval_gt_0_chk",
+          "value": "\"RecurringTransaction\".\"interval\" > 0"
+        },
+        "RecurringTransaction_amount_positive": {
+          "name": "RecurringTransaction_amount_positive",
+          "value": "\"RecurringTransaction\".\"amount\" > 0"
+        },
+        "RecurringTransaction_endDate_after_startDate": {
+          "name": "RecurringTransaction_endDate_after_startDate",
+          "value": "\"endDate\" IS NULL OR \"endDate\" > \"startDate\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.RefreshToken": {
+      "name": "RefreshToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceInfo": {
+          "name": "deviceInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RefreshToken_userId_idx": {
+          "name": "RefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RefreshToken_expiresAt_idx": {
+          "name": "RefreshToken_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RefreshToken_userId_User_id_fk": {
+          "name": "RefreshToken_userId_User_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RefreshToken_replacedByTokenId_RefreshToken_id_fk": {
+          "name": "RefreshToken_replacedByTokenId_RefreshToken_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "RefreshToken",
+          "columnsFrom": ["replacedByTokenId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "RefreshToken_token_unique": {
+          "name": "RefreshToken_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        },
+        "RefreshToken_replacedByTokenId_unique": {
+          "name": "RefreshToken_replacedByTokenId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["replacedByTokenId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TransactionCategory": {
+      "name": "TransactionCategory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentCategoryId": {
+          "name": "parentCategoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TransactionCategory_userId_name_type_parentCategoryId_key": {
+          "name": "TransactionCategory_userId_name_type_parentCategoryId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_userId_idx": {
+          "name": "TransactionCategory_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_parentCategoryId_idx": {
+          "name": "TransactionCategory_parentCategoryId_idx",
+          "columns": [
+            {
+              "expression": "parentCategoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_type_idx": {
+          "name": "TransactionCategory_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TransactionCategory_userId_not_deleted_idx": {
+          "name": "TransactionCategory_userId_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TransactionCategory_userId_User_id_fk": {
+          "name": "TransactionCategory_userId_User_id_fk",
+          "tableFrom": "TransactionCategory",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "TransactionCategory_parentCategoryId_TransactionCategory_id_fk": {
+          "name": "TransactionCategory_parentCategoryId_TransactionCategory_id_fk",
+          "tableFrom": "TransactionCategory",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["parentCategoryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "TransactionCategory_userId_id_key": {
+          "name": "TransactionCategory_userId_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["userId", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Transaction": {
+      "name": "Transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TransactionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurringTransactionId": {
+          "name": "recurringTransactionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Transaction_userId_idx": {
+          "name": "Transaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_categoryId_idx": {
+          "name": "Transaction_categoryId_idx",
+          "columns": [
+            {
+              "expression": "categoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_date_idx": {
+          "name": "Transaction_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_type_idx": {
+          "name": "Transaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_currencyCode_idx": {
+          "name": "Transaction_currencyCode_idx",
+          "columns": [
+            {
+              "expression": "currencyCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_recurringTransactionId_idx": {
+          "name": "Transaction_recurringTransactionId_idx",
+          "columns": [
+            {
+              "expression": "recurringTransactionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_userId_date_idx": {
+          "name": "Transaction_userId_date_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_userId_currencyCode_date_idx": {
+          "name": "Transaction_userId_currencyCode_date_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currencyCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_userId_currencyCode_date_expense_idx": {
+          "name": "Transaction_userId_currencyCode_date_expense_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currencyCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "type = 'EXPENSE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transaction_description_trgm_idx": {
+          "name": "Transaction_description_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"description\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Transaction_userId_User_id_fk": {
+          "name": "Transaction_userId_User_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Transaction_recurringTransactionId_RecurringTransaction_id_fk": {
+          "name": "Transaction_recurringTransactionId_RecurringTransaction_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "RecurringTransaction",
+          "columnsFrom": ["recurringTransactionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "Transaction_userId_categoryId_TransactionCategory_userId_id_fk": {
+          "name": "Transaction_userId_categoryId_TransactionCategory_userId_id_fk",
+          "tableFrom": "Transaction",
+          "tableTo": "TransactionCategory",
+          "columnsFrom": ["userId", "categoryId"],
+          "columnsTo": ["userId", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Transaction_amount_positive": {
+          "name": "Transaction_amount_positive",
+          "value": "amount > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.UserAuthIdentity": {
+      "name": "UserAuthIdentity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "AuthProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailAtLink": {
+          "name": "emailAtLink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserAuthIdentity_provider_providerId_unique": {
+          "name": "UserAuthIdentity_provider_providerId_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"UserAuthIdentity\".\"providerId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserAuthIdentity_userId_local_unique": {
+          "name": "UserAuthIdentity_userId_local_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"UserAuthIdentity\".\"provider\" = 'LOCAL'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserAuthIdentity_userId_createdAt_idx": {
+          "name": "UserAuthIdentity_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserAuthIdentity_userId_User_id_fk": {
+          "name": "UserAuthIdentity_userId_User_id_fk",
+          "tableFrom": "UserAuthIdentity",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "emailVerificationToken": {
+          "name": "emailVerificationToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerificationTokenExpiresAt": {
+          "name": "emailVerificationTokenExpiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "countryCode": {
+          "name": "countryCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseCurrencyCode": {
+          "name": "baseCurrencyCode",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingCompleted": {
+          "name": "onboardingCompleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "User_emailVerificationToken_idx": {
+          "name": "User_emailVerificationToken_idx",
+          "columns": [
+            {
+              "expression": "emailVerificationToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"User\".\"emailVerificationToken\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_id_not_deleted_idx": {
+          "name": "User_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "User_email_unique": {
+          "name": "User_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Verification": {
+      "name": "Verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Verification_identifier_key": {
+          "name": "Verification_identifier_key",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AuthProvider": {
+      "name": "AuthProvider",
+      "schema": "public",
+      "values": ["LOCAL", "GOOGLE", "GITHUB"]
+    },
+    "public.BudgetPeriod": {
+      "name": "BudgetPeriod",
+      "schema": "public",
+      "values": ["WEEKLY", "MONTHLY", "QUARTERLY", "YEARLY", "CUSTOM"]
+    },
+    "public.BudgetStatus": {
+      "name": "BudgetStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "EXCEEDED"]
+    },
+    "public.LoginStatus": {
+      "name": "LoginStatus",
+      "schema": "public",
+      "values": ["SUCCESS", "FAILED"]
+    },
+    "public.RecurringFrequency": {
+      "name": "RecurringFrequency",
+      "schema": "public",
+      "values": ["DAILY", "WEEKLY", "MONTHLY", "YEARLY"]
+    },
+    "public.RecurringTransactionStatus": {
+      "name": "RecurringTransactionStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "PAUSED", "CANCELLED"]
+    },
+    "public.TransactionType": {
+      "name": "TransactionType",
+      "schema": "public",
+      "values": ["EXPENSE", "INCOME"]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": ["USER", "ADMIN", "SUPER_ADMIN"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1776594648511,
       "tag": "0021_mushy_callisto",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1776616255733,
+      "tag": "0022_crazy_salo",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ThrottlerModule } from '@nestjs/throttler';
@@ -87,11 +87,26 @@ import { UserModule } from './modules/user/user.module.js';
     ScheduledTasksModule,
   ],
   providers: [
-    AllExceptionsFilter,
-    ProblemDetailsFilter,
-    PaginationLinkInterceptor,
-    RequestContextInterceptor,
-    TimeoutInterceptor,
+    {
+      provide: APP_FILTER,
+      useClass: AllExceptionsFilter,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: ProblemDetailsFilter,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: RequestContextInterceptor,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: TimeoutInterceptor,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: PaginationLinkInterceptor,
+    },
     {
       provide: APP_INTERCEPTOR,
       useClass: AuditLogInterceptor,

--- a/src/app/filters/all-exceptions.filter.ts
+++ b/src/app/filters/all-exceptions.filter.ts
@@ -1,3 +1,4 @@
+import { inspect } from 'node:util';
 import { Catch, HttpStatus, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ClsService } from 'nestjs-cls';
@@ -49,11 +50,23 @@ export class AllExceptionsFilter implements ExceptionFilter {
     if (exception instanceof Error) {
       this.logger.error(logMessage, exception.stack);
     } else {
-      this.logger.error(logMessage, JSON.stringify(exception));
+      this.logger.error(logMessage, safeStringify(exception));
     }
 
     response.setHeader('Content-Type', 'application/problem+json');
     response.setHeader('Cache-Control', 'no-store');
     response.status(status).json(problemDetails);
+  }
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    try {
+      return inspect(value, { depth: 3, breakLength: Infinity });
+    } catch {
+      return '[Unserializable exception]';
+    }
   }
 }

--- a/src/app/filters/all-exceptions.filter.ts
+++ b/src/app/filters/all-exceptions.filter.ts
@@ -1,4 +1,4 @@
-import { Catch, HttpException, HttpStatus, Inject, Logger } from '@nestjs/common';
+import { Catch, HttpStatus, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ClsService } from 'nestjs-cls';
 import type { ExceptionFilter, ArgumentsHost } from '@nestjs/common';
@@ -6,7 +6,6 @@ import type { Request, Response } from 'express';
 
 import type { ProblemDetailsDto } from '@/shared/dtos/problem-details.dto.js';
 
-import { ProblemDetailsFilter } from './problem-details.filter.js';
 import type { Env } from '../config/env.schema.js';
 
 @Catch()
@@ -15,8 +14,6 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
   constructor(
     private readonly cls: ClsService,
-    @Inject(ProblemDetailsFilter)
-    private readonly problemDetailsFilter: ProblemDetailsFilter,
     private readonly configService: ConfigService<Env, true>,
   ) {}
 
@@ -24,10 +21,6 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const context = host.switchToHttp();
     const response = context.getResponse<Response>();
     const request = context.getRequest<Request>();
-
-    if (exception instanceof HttpException) {
-      return this.problemDetailsFilter.catch(exception, host);
-    }
 
     const status = HttpStatus.INTERNAL_SERVER_ERROR;
 

--- a/src/database/schemas/budgets.ts
+++ b/src/database/schemas/budgets.ts
@@ -48,7 +48,15 @@ export const budgets = pgTable(
     index('Budget_status_endDate_idx')
       .on(table.status, table.endDate)
       .where(sql`status IN ('ACTIVE', 'EXCEEDED')`),
+    index('Budget_userId_status_idx').on(table.userId, table.status),
+    index('Budget_userId_currencyCode_startDate_endDate_idx').on(
+      table.userId,
+      table.currencyCode,
+      table.startDate,
+      table.endDate,
+    ),
     check('Budget_endDate_after_startDate', sql`"endDate" > "startDate"`),
+    check('Budget_amount_positive', sql`${table.amount} > 0`),
   ],
 );
 

--- a/src/database/schemas/recurring-transactions.ts
+++ b/src/database/schemas/recurring-transactions.ts
@@ -54,6 +54,7 @@ export const recurringTransactions = pgTable(
   },
   (table) => [
     check('RecurringTransaction_interval_gt_0_chk', sql`${table.interval} > 0`),
+    check('RecurringTransaction_amount_positive', sql`${table.amount} > 0`),
     check(
       'RecurringTransaction_endDate_after_startDate',
       sql`"endDate" IS NULL OR "endDate" > "startDate"`,

--- a/src/database/schemas/transactions.ts
+++ b/src/database/schemas/transactions.ts
@@ -55,6 +55,9 @@ export const transactions = pgTable(
       table.currencyCode,
       table.date.desc(),
     ),
+    index('Transaction_userId_currencyCode_date_expense_idx')
+      .on(table.userId, table.currencyCode, table.date.desc())
+      .where(sql`type = 'EXPENSE'`),
     foreignKey({
       columns: [table.userId, table.categoryId],
       foreignColumns: [transactionCategories.userId, transactionCategories.id],

--- a/src/database/schemas/verifications.ts
+++ b/src/database/schemas/verifications.ts
@@ -1,4 +1,4 @@
-import { index, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
 
 export const verifications = pgTable(
   'Verification',
@@ -15,5 +15,5 @@ export const verifications = pgTable(
       .defaultNow()
       .$onUpdate(() => new Date()),
   },
-  (table) => [index('Verification_identifier_idx').on(table.identifier)],
+  (table) => [uniqueIndex('Verification_identifier_key').on(table.identifier)],
 );

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,11 +10,6 @@ import type { NestExpressApplication } from '@nestjs/platform-express';
 import { createCorsConfig } from './app/config/cors.config.js';
 import { setupSwagger } from './app/config/swagger.config.js';
 import { createValidationPipe } from './app/config/validation.config.js';
-import { AllExceptionsFilter } from './app/filters/all-exceptions.filter.js';
-import { ProblemDetailsFilter } from './app/filters/problem-details.filter.js';
-import { PaginationLinkInterceptor } from './app/interceptors/pagination-link.interceptor.js';
-import { RequestContextInterceptor } from './app/interceptors/request-context.interceptor.js';
-import { TimeoutInterceptor } from './app/interceptors/timeout.interceptor.js';
 import { AppModule } from './app.module.js';
 import type { Env } from './app/config/env.schema.js';
 
@@ -40,14 +35,6 @@ async function bootstrap() {
       { path: 'auth/github/callback', method: RequestMethod.GET },
     ],
   });
-
-  app.useGlobalFilters(app.get(ProblemDetailsFilter), app.get(AllExceptionsFilter));
-
-  app.useGlobalInterceptors(
-    app.get(RequestContextInterceptor),
-    app.get(TimeoutInterceptor),
-    app.get(PaginationLinkInterceptor),
-  );
 
   app.useGlobalPipes(createValidationPipe());
 

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -333,7 +333,10 @@ export class AuthController {
     req: { user: SocialLoginParams } & HttpRequest,
     res: Response,
   ): Promise<void> {
-    const redirectUrl = this.socialAuthRedirectUrl as string;
+    if (!this.socialAuthRedirectUrl) {
+      throw new InternalServerErrorException('Social auth redirect URL is not configured');
+    }
+    const redirectUrl = this.socialAuthRedirectUrl;
 
     try {
       const result = await this.authService.socialLogin({

--- a/src/modules/budgets/budgets.controller.ts
+++ b/src/modules/budgets/budgets.controller.ts
@@ -87,7 +87,7 @@ export class BudgetsController {
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'Create a budget' })
   @ApiResponse({ status: 201, type: BudgetResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 422, description: 'Validation error' })
   @ApiResponse({ status: 404, description: 'Category not found' })
   @ApiResponse({ status: 409, description: 'Overlapping budget exists' })
   async create(
@@ -109,7 +109,7 @@ export class BudgetsController {
   @Patch(':id')
   @ApiOperation({ summary: 'Update a budget' })
   @ApiResponse({ status: 200, type: BudgetResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 422, description: 'Validation error' })
   @ApiResponse({ status: 404, description: 'Budget not found' })
   @ApiResponse({ status: 409, description: 'Overlapping budget exists' })
   async update(
@@ -129,7 +129,7 @@ export class BudgetsController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Bulk delete budgets' })
   @ApiResponse({ status: 200, type: BulkDeleteResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 422, description: 'Validation error' })
   async bulkDelete(
     @Body() dto: BulkDeleteDto,
     @Request() req: AuthenticatedRequest,

--- a/src/modules/budgets/dtos/create-budget.dto.ts
+++ b/src/modules/budgets/dtos/create-budget.dto.ts
@@ -20,7 +20,7 @@ export class CreateBudgetDto {
   @ApiProperty({ example: '500.00' })
   @IsStringField()
   @IsNotEmptyField()
-  @MatchesField(/^\d{1,17}(\.\d{1,2})?$/)
+  @MatchesField(/^(?!0+(?:\.0{1,2})?$)\d{1,17}(\.\d{1,2})?$/)
   amount!: string;
 
   @ApiProperty({

--- a/src/modules/budgets/dtos/update-budget.dto.ts
+++ b/src/modules/budgets/dtos/update-budget.dto.ts
@@ -15,7 +15,7 @@ export class UpdateBudgetDto {
   @IsOptional()
   @IsStringField()
   @IsNotEmptyField()
-  @MatchesField(/^\d{1,17}(\.\d{1,2})?$/)
+  @MatchesField(/^(?!0+(?:\.0{1,2})?$)\d{1,17}(\.\d{1,2})?$/)
   amount?: string;
 
   @ApiPropertyOptional({ example: '550e8400-e29b-41d4-a716-446655440000' })

--- a/src/modules/onboarding/onboarding.controller.ts
+++ b/src/modules/onboarding/onboarding.controller.ts
@@ -28,7 +28,8 @@ export class OnboardingController {
   @HttpCode(200)
   @ApiOperation({ summary: 'Complete onboarding' })
   @ApiResponse({ status: 200, type: OnboardingStatusResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation error or missing requirements' })
+  @ApiResponse({ status: 400, description: 'Missing requirements' })
+  @ApiResponse({ status: 422, description: 'Validation error' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async complete(
     @Request() req: AuthenticatedRequest,

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -39,7 +39,7 @@ export class ProfileController {
   @Patch()
   @ApiOperation({ summary: 'Update current user profile' })
   @ApiResponse({ status: 200, type: ProfileResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 422, description: 'Validation error' })
   async updateProfile(
     @Request() req: AuthenticatedRequest,
     @Body() dto: UpdateProfileDto,

--- a/src/modules/recurring-transactions/dtos/create-recurring-transaction.dto.ts
+++ b/src/modules/recurring-transactions/dtos/create-recurring-transaction.dto.ts
@@ -38,7 +38,7 @@ export class CreateRecurringTransactionDto {
   @ApiProperty({ example: '49.99' })
   @IsStringField()
   @IsNotEmptyField()
-  @MatchesField(/^\d{1,17}(\.\d{1,2})?$/)
+  @MatchesField(/^(?!0+(?:\.0{1,2})?$)\d{1,17}(\.\d{1,2})?$/)
   amount!: string;
 
   @ApiProperty({

--- a/src/modules/recurring-transactions/dtos/update-recurring-transaction.dto.ts
+++ b/src/modules/recurring-transactions/dtos/update-recurring-transaction.dto.ts
@@ -41,7 +41,7 @@ export class UpdateRecurringTransactionDto {
   @IsOptional()
   @IsStringField()
   @IsNotEmptyField()
-  @MatchesField(/^\d{1,17}(\.\d{1,2})?$/)
+  @MatchesField(/^(?!0+(?:\.0{1,2})?$)\d{1,17}(\.\d{1,2})?$/)
   amount?: string;
 
   @ApiPropertyOptional({

--- a/src/modules/recurring-transactions/recurring-transactions.controller.ts
+++ b/src/modules/recurring-transactions/recurring-transactions.controller.ts
@@ -14,6 +14,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 
 import { Roles } from '@/shared/decorators/roles.decorator.js';
 import { BulkDeleteDto } from '@/shared/dtos/bulk-delete.dto.js';
@@ -79,7 +80,7 @@ export class RecurringTransactionsController {
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'Create a recurring transaction' })
   @ApiResponse({ status: 201, type: RecurringTransactionResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 422, description: 'Validation error' })
   @ApiResponse({ status: 404, description: 'Category not found' })
   async create(
     @Body() dto: CreateRecurringTransactionDto,
@@ -102,7 +103,7 @@ export class RecurringTransactionsController {
   @Patch(':id')
   @ApiOperation({ summary: 'Update a recurring transaction' })
   @ApiResponse({ status: 200, type: RecurringTransactionResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 422, description: 'Validation error' })
   @ApiResponse({ status: 404, description: 'Recurring transaction not found' })
   async update(
     @Param('id', ParseUUIDPipe) id: string,
@@ -126,7 +127,7 @@ export class RecurringTransactionsController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Bulk delete (cancel) recurring transactions' })
   @ApiResponse({ status: 200, type: BulkDeleteResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 422, description: 'Validation error' })
   async bulkDelete(
     @Body() dto: BulkDeleteDto,
     @Request() req: AuthenticatedRequest,
@@ -176,6 +177,7 @@ export class RecurringTransactionsController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(RolesGuard)
   @Roles('ADMIN')
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @ApiOperation({ summary: 'Process due recurring transactions' })
   @ApiResponse({ status: 200, type: ProcessResultResponseDto })
   @ApiResponse({ status: 403, description: 'Insufficient permissions' })

--- a/src/modules/recurring-transactions/recurring-transactions.repository.ts
+++ b/src/modules/recurring-transactions/recurring-transactions.repository.ts
@@ -26,6 +26,7 @@ import type { RecurringFrequency } from '@/shared/enums/recurring-frequency.enum
 import type { RecurringTransactionStatus } from '@/shared/enums/recurring-transaction-status.enum.js';
 import type { TransactionType } from '@/shared/enums/transaction-type.enum.js';
 import type { CategoryDetail, CategoryJoinColumns } from '@/shared/types/category-detail.js';
+import { fetchCategoryJoinColumns } from '@/shared/utils/fetch-category-columns.js';
 
 import type { SortByField } from './recurring-transactions.constants.js';
 
@@ -284,7 +285,7 @@ export class RecurringTransactionsRepository {
       throw new Error('Failed to create recurring transaction');
     }
 
-    const categoryInfo = await this.getCategoryInfo(inserted.categoryId, db);
+    const categoryInfo = await fetchCategoryJoinColumns(inserted.categoryId, db);
 
     return this.toRecurringTransactionInfo({ ...inserted, ...categoryInfo });
   }
@@ -333,18 +334,18 @@ export class RecurringTransactionsRepository {
       updates.status = data.status;
     }
 
-    const updated = (await db
+    const updated = await db
       .update(recurringTransactions)
       .set(updates)
       .where(and(eq(recurringTransactions.id, id), eq(recurringTransactions.userId, userId)))
-      .returning()) as (typeof recurringTransactions.$inferSelect)[];
+      .returning();
 
     const [updatedRow] = updated;
     if (!updatedRow) {
       return null;
     }
 
-    const categoryInfo = await this.getCategoryInfo(updatedRow.categoryId, db);
+    const categoryInfo = await fetchCategoryJoinColumns(updatedRow.categoryId, db);
 
     return this.toRecurringTransactionInfo({ ...updatedRow, ...categoryInfo });
   }
@@ -425,27 +426,6 @@ export class RecurringTransactionsRepository {
         recurringTransactionId: d.recurringTransactionId,
       })),
     );
-  }
-
-  private async getCategoryInfo(categoryId: string, db: DrizzleDb): Promise<CategoryJoinColumns> {
-    const result = (await db
-      .select({
-        categoryName: transactionCategories.name,
-        parentCatId: parentCategory.id,
-        parentCatName: parentCategory.name,
-      })
-      .from(transactionCategories)
-      .leftJoin(parentCategory, eq(transactionCategories.parentCategoryId, parentCategory.id))
-      .where(eq(transactionCategories.id, categoryId))
-      .limit(1)) as CategoryJoinColumns[];
-
-    const [row] = result;
-
-    return {
-      categoryName: row?.categoryName ?? null,
-      parentCatId: row?.parentCatId ?? null,
-      parentCatName: row?.parentCatName ?? null,
-    };
   }
 
   private toRecurringTransactionInfo(

--- a/src/modules/transaction-categories/transaction-categories.controller.ts
+++ b/src/modules/transaction-categories/transaction-categories.controller.ts
@@ -107,7 +107,7 @@ export class TransactionCategoriesController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Bulk delete transaction categories' })
   @ApiResponse({ status: 200, type: BulkDeleteResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 422, description: 'Validation error' })
   async bulkDelete(
     @Body() dto: BulkDeleteDto,
     @Request() req: AuthenticatedRequest,

--- a/src/modules/transactions-analytics/transactions-analytics.repository.ts
+++ b/src/modules/transactions-analytics/transactions-analytics.repository.ts
@@ -189,7 +189,7 @@ export class TransactionsAnalyticsRepository {
 
   async getDailyTotals(query: AnalyticsBaseQuery): Promise<DailyTotalRow[]> {
     const conditions = this.buildBaseConditions(query);
-    const dayExpr = sql`${transactions.date}::date`;
+    const dayExpr: SQL = sql`${transactions.date}::date`;
 
     const rows = await this.db
       .select({

--- a/src/modules/transactions-analytics/transactions-analytics.repository.ts
+++ b/src/modules/transactions-analytics/transactions-analytics.repository.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { and, count, eq, gte, lte, sql } from 'drizzle-orm';
+import { and, count, desc, eq, gte, lte, sql } from 'drizzle-orm';
 import type { SQL } from 'drizzle-orm';
 
 import { transactionCategories, transactions } from '@/database/schemas/index.js';
@@ -110,7 +110,7 @@ export class TransactionsAnalyticsRepository {
       .innerJoin(transactionCategories, eq(transactions.categoryId, transactionCategories.id))
       .where(and(...conditions))
       .groupBy(transactions.categoryId, transactionCategories.name, transactions.type)
-      .orderBy(sql`total DESC`);
+      .orderBy(desc(sql`SUM(${transactions.amount})`));
 
     return rows.map((row) => ({
       categoryId: row.categoryId,
@@ -175,7 +175,7 @@ export class TransactionsAnalyticsRepository {
       .innerJoin(transactionCategories, eq(transactions.categoryId, transactionCategories.id))
       .where(and(...conditions))
       .groupBy(transactions.categoryId, transactionCategories.name, transactions.type)
-      .orderBy(sql`total DESC`)
+      .orderBy(desc(sql`SUM(${transactions.amount})`))
       .limit(limit);
 
     return rows.map((row) => ({
@@ -189,17 +189,18 @@ export class TransactionsAnalyticsRepository {
 
   async getDailyTotals(query: AnalyticsBaseQuery): Promise<DailyTotalRow[]> {
     const conditions = this.buildBaseConditions(query);
+    const dayExpr = sql`${transactions.date}::date`;
 
     const rows = await this.db
       .select({
-        date: sql<string>`${transactions.date}::date`.as('day'),
+        date: sql<string>`${dayExpr}`.as('day'),
         total: sql<string>`COALESCE(SUM(${transactions.amount}), 0)`.as('total'),
         transactionCount: count(),
       })
       .from(transactions)
       .where(and(...conditions))
-      .groupBy(sql`day`)
-      .orderBy(sql`day`);
+      .groupBy(dayExpr)
+      .orderBy(dayExpr);
 
     return rows.map((row) => ({
       date: row.date,

--- a/src/modules/transactions/transactions.controller.ts
+++ b/src/modules/transactions/transactions.controller.ts
@@ -174,6 +174,7 @@ export class TransactionsController {
   @ApiResponse({ status: 201, type: TransactionResponseDto })
   @ApiResponse({ status: 400, description: 'Category type mismatch' })
   @ApiResponse({ status: 404, description: 'Category not found' })
+  @ApiResponse({ status: 422, description: 'Validation error' })
   async create(
     @Body() dto: CreateTransactionDto,
     @Request() req: AuthenticatedRequest,
@@ -194,6 +195,7 @@ export class TransactionsController {
   @ApiResponse({ status: 200, type: TransactionResponseDto })
   @ApiResponse({ status: 400, description: 'Category type mismatch' })
   @ApiResponse({ status: 404, description: 'Transaction not found' })
+  @ApiResponse({ status: 422, description: 'Validation error' })
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: UpdateTransactionDto,

--- a/src/modules/transactions/transactions.controller.ts
+++ b/src/modules/transactions/transactions.controller.ts
@@ -213,7 +213,7 @@ export class TransactionsController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Bulk delete transactions' })
   @ApiResponse({ status: 200, type: BulkDeleteResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 422, description: 'Validation error' })
   async bulkDelete(
     @Body() dto: BulkDeleteDto,
     @Request() req: AuthenticatedRequest,

--- a/src/modules/transactions/transactions.repository.ts
+++ b/src/modules/transactions/transactions.repository.ts
@@ -23,6 +23,7 @@ import type { SortOrder } from '@/shared/constants/sort.constants.js';
 import type { CurrencyCode } from '@/shared/enums/currency-code.enum.js';
 import type { TransactionType } from '@/shared/enums/transaction-type.enum.js';
 import type { CategoryDetail, CategoryJoinColumns } from '@/shared/types/category-detail.js';
+import { fetchCategoryJoinColumns } from '@/shared/utils/fetch-category-columns.js';
 
 import type { SortByField } from './transactions.constants.js';
 
@@ -274,7 +275,7 @@ export class TransactionRepository {
       throw new Error('Failed to create transaction');
     }
 
-    const categoryInfo = await this.getCategoryInfo(inserted.categoryId, db);
+    const categoryInfo = await fetchCategoryJoinColumns(inserted.categoryId, db);
 
     return this.toTransactionInfo({ ...inserted, ...categoryInfo });
   }
@@ -313,18 +314,18 @@ export class TransactionRepository {
       updates.description = data.description;
     }
 
-    const updated = (await db
+    const updated = await db
       .update(transactions)
       .set(updates)
       .where(and(eq(transactions.id, id), eq(transactions.userId, userId)))
-      .returning()) as (typeof transactions.$inferSelect)[];
+      .returning();
 
     const [row] = updated;
     if (!row) {
       return null;
     }
 
-    const categoryInfo = await this.getCategoryInfo(row.categoryId, db);
+    const categoryInfo = await fetchCategoryJoinColumns(row.categoryId, db);
 
     return this.toTransactionInfo({ ...row, ...categoryInfo });
   }
@@ -482,27 +483,6 @@ export class TransactionRepository {
       .returning({ id: transactions.id });
 
     return result.length;
-  }
-
-  private async getCategoryInfo(categoryId: string, db: DrizzleDb): Promise<CategoryJoinColumns> {
-    const result = (await db
-      .select({
-        categoryName: transactionCategories.name,
-        parentCatId: parentCategory.id,
-        parentCatName: parentCategory.name,
-      })
-      .from(transactionCategories)
-      .leftJoin(parentCategory, eq(transactionCategories.parentCategoryId, parentCategory.id))
-      .where(eq(transactionCategories.id, categoryId))
-      .limit(1)) as CategoryJoinColumns[];
-
-    const [row] = result;
-
-    return {
-      categoryName: row?.categoryName ?? null,
-      parentCatId: row?.parentCatId ?? null,
-      parentCatName: row?.parentCatName ?? null,
-    };
   }
 
   private toTransactionInfo(

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -120,9 +120,13 @@ export class UserController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Delete user' })
   @ApiResponse({ status: 200, type: MessageResponseDto })
+  @ApiResponse({ status: 403, description: 'Cannot delete own account' })
   @ApiResponse({ status: 404, description: 'User not found' })
-  async delete(@Param('id', ParseUUIDPipe) id: string): Promise<MessageResponseDto> {
-    await this.userService.delete(id);
+  async delete(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<MessageResponseDto> {
+    await this.userService.delete(id, req.user.id);
 
     return { message: 'User deleted successfully' };
   }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -182,7 +182,14 @@ export class UserService {
     return updated;
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(id: string, actorId: string): Promise<void> {
+    if (id === actorId) {
+      throw new ForbiddenException({
+        code: ErrorCode.FORBIDDEN,
+        message: 'Deleting your own account is not allowed',
+      });
+    }
+
     const deleted = await this.userRepository.hardDelete(id);
     if (!deleted) {
       throw new NotFoundException({

--- a/src/shared/utils/fetch-category-columns.ts
+++ b/src/shared/utils/fetch-category-columns.ts
@@ -1,0 +1,31 @@
+import { aliasedTable, eq } from 'drizzle-orm';
+
+import { transactionCategories } from '@/database/schemas/index.js';
+import type { DrizzleDb } from '@/database/types.js';
+import type { CategoryJoinColumns } from '@/shared/types/category-detail.js';
+
+const parentCategory = aliasedTable(transactionCategories, 'parentCategory');
+
+export async function fetchCategoryJoinColumns(
+  categoryId: string,
+  db: DrizzleDb,
+): Promise<CategoryJoinColumns> {
+  const result = (await db
+    .select({
+      categoryName: transactionCategories.name,
+      parentCatId: parentCategory.id,
+      parentCatName: parentCategory.name,
+    })
+    .from(transactionCategories)
+    .leftJoin(parentCategory, eq(transactionCategories.parentCategoryId, parentCategory.id))
+    .where(eq(transactionCategories.id, categoryId))
+    .limit(1)) as CategoryJoinColumns[];
+
+  const [row] = result;
+
+  return {
+    categoryName: row?.categoryName ?? null,
+    parentCatId: row?.parentCatId ?? null,
+    parentCatName: row?.parentCatName ?? null,
+  };
+}

--- a/src/shared/utils/fetch-category-columns.ts
+++ b/src/shared/utils/fetch-category-columns.ts
@@ -1,31 +1,39 @@
-import { aliasedTable, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 
 import { transactionCategories } from '@/database/schemas/index.js';
 import type { DrizzleDb } from '@/database/types.js';
 import type { CategoryJoinColumns } from '@/shared/types/category-detail.js';
 
-const parentCategory = aliasedTable(transactionCategories, 'parentCategory');
-
 export async function fetchCategoryJoinColumns(
   categoryId: string,
   db: DrizzleDb,
 ): Promise<CategoryJoinColumns> {
-  const result = (await db
+  const [category] = await db
     .select({
-      categoryName: transactionCategories.name,
-      parentCatId: parentCategory.id,
-      parentCatName: parentCategory.name,
+      name: transactionCategories.name,
+      parentCategoryId: transactionCategories.parentCategoryId,
     })
     .from(transactionCategories)
-    .leftJoin(parentCategory, eq(transactionCategories.parentCategoryId, parentCategory.id))
     .where(eq(transactionCategories.id, categoryId))
-    .limit(1)) as CategoryJoinColumns[];
+    .limit(1);
 
-  const [row] = result;
+  if (!category) {
+    return { categoryName: null, parentCatId: null, parentCatName: null };
+  }
+
+  if (!category.parentCategoryId) {
+    return { categoryName: category.name, parentCatId: null, parentCatName: null };
+  }
+
+  const [parent] = await db
+    .select({ name: transactionCategories.name })
+    .from(transactionCategories)
+    .where(eq(transactionCategories.id, category.parentCategoryId))
+    .limit(1);
 
   return {
-    categoryName: row?.categoryName ?? null,
-    parentCatId: row?.parentCatId ?? null,
-    parentCatName: row?.parentCatName ?? null,
+    categoryName: category.name,
+    parentCatId: category.parentCategoryId,
+    parentCatName: parent?.name ?? null,
   };
 }


### PR DESCRIPTION
## Summary

Implements 14 P2 audit findings from `IMPROVEMENTS.md` (#69–80, #83, #85, #86):

- **Security** (#70, #71): admin self-delete guard in `UserService.delete`; runtime guard on `socialAuthRedirectUrl` replacing an unsafe `as string`. #69 was already fixed (existsByEmail filters `isNull(deletedAt)`).
- **DB constraints & indexes** (#75, #76, #77, #79, #80): `CHECK (amount > 0)` on Budget + RecurringTransaction; unique index on `Verification.identifier`; composite indexes on Budget (`userId,status` and `userId,currencyCode,startDate,endDate`); partial index on Transaction for `EXPENSE`. Migration `drizzle/0022_crazy_salo.sql` bundles all five.
- **API correctness** (#72, #74, #86): Swagger `400 'Validation error'` → `422` across 10 controllers (kept 400 for real `BadRequestException` paths); `@Throttle` on `POST /recurring-transactions/process`; filters/interceptors moved to `APP_FILTER`/`APP_INTERCEPTOR` DI tokens and dead `HttpException` delegation in `AllExceptionsFilter` removed.
- **Refactor & types** (#78, #83, #85): replaced alias-based `GROUP BY`/`ORDER BY` with expression refs in analytics repo; extracted duplicated `getCategoryInfo` into `src/shared/utils/fetch-category-columns.ts`; removed `as (typeof table.$inferSelect)[]` casts on `.returning()` in both update methods.
- **#73 marked N/A**: DB column is `.notNull()` and service always populates `endDate` — response DTO typing was correct.

## Test plan

- [ ] `pnpm check-types` passes
- [ ] `pnpm lint:fix && pnpm format` clean
- [ ] Run `pnpm db:migrate` on a dev DB; verify all new indexes and constraints created without error
- [ ] Pre-deploy sanity: `SELECT count(*) FROM "Budget" WHERE amount <= 0;` and same for `RecurringTransaction` (should be 0)
- [ ] Pre-deploy sanity: `SELECT identifier, count(*) FROM "Verification" GROUP BY 1 HAVING count(*) > 1;` (should be 0) before unique index applies
- [ ] Manual smoke: admin attempts `DELETE /users/<own-id>` → 403; admin deletes another user → 200
- [ ] Manual smoke: trigger validation error on any endpoint → response is 422 (not 400)
- [ ] Manual smoke: POST `/recurring-transactions/process` 6 times within a minute as admin → 6th is throttled (429)
- [ ] Swagger UI at `/docs` reflects 422 on the updated endpoints and 400 on real `BadRequestException` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented users from deleting their own accounts
  * Added validation for missing configuration in authentication flow
  * Enhanced data integrity with amount validation constraints

* **Improvements**
  * Optimized database performance through strategic indexing
  * Added rate limiting to recurring transaction processing (5 requests per 60 seconds)
  * Implemented unique identifier enforcement for verification records

* **Documentation**
  * Corrected API response status codes to accurately reflect validation errors (422 instead of 400)
  * Updated improvements documentation with current findings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->